### PR TITLE
Support Unicode characters with higher codepoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "commander": "^2.8.1",
     "readable-stream": "^2.0.0",
     "sax": "1.1.x",
+    "string.fromcodepoint": "^0.2.1",
+    "string.prototype.codepointat": "^0.2.0",
     "svg-pathdata": "1.0.0"
   },
   "devDependencies": {

--- a/src/iconsdir.js
+++ b/src/iconsdir.js
@@ -4,6 +4,8 @@ var path = require('path');
 
 var Readable = require('stream').Readable;
 
+require('string.prototype.codepointat');
+
 // Inherit of duplex stream
 util.inherits(SVGIconsDirStream, Readable);
 
@@ -59,7 +61,7 @@ function SVGIconsDirStream(dir, options) {
         } else {
           if(metadata.renamed) {
             options.log('Saved codepoint: ' +
-              'u' + metadata.unicode[0].charCodeAt(0).toString(16).toUpperCase() +
+              'u' + metadata.unicode[0].codePointAt(0).toString(16).toUpperCase() +
               ' for the glyph "' + metadata.name + '"');
           }
           filesInfos.push(metadata);

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@
  */
 "use strict";
 
+require('string.prototype.codepointat');
+
 // Transform helpers (will move elsewhere later)
 function parseTransforms(value) {
  return value.match(
@@ -412,7 +414,7 @@ function SVGIcons2SVGFontStream(options) {
             _this.push('\
     <glyph glyph-name="' + glyph.name + (i == 0 ? '' : '-' + i) + '"\n\
       unicode="' + unicode.split('').map(function(char) {
-        return '&#x' + char.charCodeAt(0).toString(16).toUpperCase() + ';';
+        return '&#x' + char.codePointAt(0).toString(16).toUpperCase() + ';';
       }).join('') + '"\n\
       horiz-adv-x="' + glyph.width + '" d="' + d +'" />\n');
           });

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -1,6 +1,9 @@
 var path = require('path');
 var fs = require('fs');
 
+require('string.fromcodepoint');
+require('string.prototype.codepointat');
+
 function getMetadataService(options) {
   var usedUnicodes = [];
   // Default options
@@ -28,7 +31,7 @@ function getMetadataService(options) {
       metadata.unicode = matches[1].split(',').map(function(match) {
         match = match.substr(1);
         return match.split('u').map(function(code) {
-          return String.fromCharCode(parseInt(code, 16));
+          return String.fromCodePoint(parseInt(code, 16));
         }).join('');
       });
       if(-1 !== usedUnicodes.indexOf(metadata.unicode[0])) {
@@ -38,19 +41,19 @@ function getMetadataService(options) {
       usedUnicodes = usedUnicodes.concat(metadata.unicode);
     } else {
       do {
-        metadata.unicode[0] = String.fromCharCode(options.startUnicode++);
+        metadata.unicode[0] = String.fromCodePoint(options.startUnicode++);
       } while(-1 !== usedUnicodes.indexOf(metadata.unicode[0]));
       usedUnicodes.push(metadata.unicode[0]);
       if(options.appendUnicode) {
         metadata.renamed = true;
         metadata.path = path.dirname(file) + '/' +
-          'u' + metadata.unicode[0].charCodeAt(0).toString(16).toUpperCase() +
+          'u' + metadata.unicode[0].codePointAt(0).toString(16).toUpperCase() +
           '-' + basename;
         fs.rename(file, metadata.path,
           function(err) {
             if(err) {
               return cb(new Error('Could not save codepoint: ' +
-                'u' + metadata.unicode[0].charCodeAt(0).toString(16).toUpperCase() +
+                'u' + metadata.unicode[0].codePointAt(0).toString(16).toUpperCase() +
                 ' for ' + basename));
             }
             cb(null, metadata);

--- a/tests/metadata.mocha.js
+++ b/tests/metadata.mocha.js
@@ -2,6 +2,8 @@ var metadata = require(__dirname + '/../src/metadata.js');
 var fs = require('fs');
 var assert = require('assert');
 
+require('string.fromcodepoint');
+
 describe('Metadata service', function() {
 
   describe('for code generation', function() {
@@ -95,6 +97,21 @@ describe('Metadata service', function() {
             path: '/var/plop/u0001,u0002-hello.svg',
             name: 'hello',
             unicode: [String.fromCharCode(0x0001), String.fromCharCode(0x0002)],
+            renamed: false
+          }
+        );
+        done();
+      });
+    });
+
+    it("should work for higher codepoint codes", function(done) {
+      var metadataService = metadata();
+      metadataService('/var/plop/u1F63A-hello.svg', function(err, infos) {
+        assert(!err);
+        assert.deepEqual(infos, {
+            path: '/var/plop/u1F63A-hello.svg',
+            name: 'hello',
+            unicode: [String.fromCodePoint(0x1f63a)],
             renamed: false
           }
         );


### PR DESCRIPTION
... (outside of Basic Multilingual Plane)

Use String.fromCodePoint (with polyfill) instead of String.fromCharCode
Use String.codePointAt (with polyfill) where appropriate instead of String.charCodeAt