### PR TITLE
made Font ID optionally settable

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ svgicons2svgfont --help
 #    -v, --verbose               tell me everything!
 #    -o, --output [/dev/stdout]  Output file.
 #    -f, --fontname [value]      the font family name you want [iconfont].
+#    -i, --fontid [value]        The font id you want [fontname]
 #    -st, --style [value]        the font style you want [iconfont].
 #    -we, --weight [value]       the font weight you want [iconfont].
 #    -w, --fixedWidth            creates a monospace font of the width of the largest input icon.
@@ -107,6 +108,12 @@ Type: `String`
 Default value: `'iconfont'`
 
 The font family name you want.
+
+#### options.fontId
+Type: `String`
+Default value: the options.fontName value
+
+The font id you want.
 
 #### options.fontStyle
 Type: `String`

--- a/bin/svgicons2svgfont.js
+++ b/bin/svgicons2svgfont.js
@@ -14,6 +14,7 @@ program
   .option('-v, --verbose', 'tell me everything!')
   .option('-o, --output [/dev/stdout]', 'Output file.')
   .option('-f, --fontname [value]', 'the font family name you want [iconfont].')
+  .option('-f, --fontid [value]', 'the font id you want [fontname].')
   .option('-st, --style [value]', 'the font style you want.')
   .option('-we, --weight [value]', 'the font weight you want.')
   .option('-w, --fixedWidth', 'creates a monospace font of the width of the largest input icon.')
@@ -42,6 +43,7 @@ svgiconsdir(program.args, {
 })
   .pipe(svgicons2svgfont({
     fontName: program.fontname,
+	fontId: program.fontid,
     fixedwidth: program.fixedwidth,
     centerhorizontally: program.centerHorizontally,
     normalize: program.normalize,

--- a/bin/svgicons2svgfont.js
+++ b/bin/svgicons2svgfont.js
@@ -14,7 +14,7 @@ program
   .option('-v, --verbose', 'tell me everything!')
   .option('-o, --output [/dev/stdout]', 'Output file.')
   .option('-f, --fontname [value]', 'the font family name you want [iconfont].')
-  .option('-f, --fontid [value]', 'the font id you want [fontname].')
+  .option('-i, --fontid [value]', 'the font id you want [fontname].')
   .option('-st, --style [value]', 'the font style you want.')
   .option('-we, --weight [value]', 'the font weight you want.')
   .option('-w, --fixedWidth', 'creates a monospace font of the width of the largest input icon.')

--- a/src/index.js
+++ b/src/index.js
@@ -179,6 +179,7 @@ function SVGIcons2SVGFontStream(options) {
 
   options = options || {};
   options.fontName = options.fontName || 'iconfont';
+  options.fontId = options.fontId || options.fontName;
   options.fixedWidth = options.fixedWidth || false;
   options.descent = options.descent || 0;
   options.round = options.round || 10e12;
@@ -359,7 +360,7 @@ function SVGIcons2SVGFontStream(options) {
   options.metadata ? '<metadata>' + options.metadata + '</metadata>\n' : ''
 ) + '\
 <defs>\n\
-  <font id="' + options.fontName + '" horiz-adv-x="' + fontWidth + '">\n\
+  <font id="' + options.fontId + '" horiz-adv-x="' + fontWidth + '">\n\
     <font-face font-family="' + options.fontName + '"\n\
       units-per-em="' + fontHeight + '" ascent="' + options.ascent + '"\n\
       descent="' + options.descent + '"' + (options.fontWeight ? '\n\


### PR DESCRIPTION
I have added the option to set a font ID that may be different from the fontName. If the fontId is not specified it takes the fontName by default to preserve compatibility.