### PR TITLE
Add warning text when the fontHeight is smaller than 1000

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -293,6 +293,12 @@ function SVGIcons2SVGFontStream(options) {
         ' to unexpected results. Using the normalize option could' +
         ' solve the problem.');
     }
+    if(fontHeight < 1000) {
+      log('The fontHeight should larger than 1000 or it will be converted ' +
+          'into the wrong shape. Using the "normalize" and "fontHeight"' +
+          ' options can solve the problem.');
+    }
+
     // Output the SVG file
     // (find a SAX parser that allows modifying SVG on the fly)
     _this.push('\


### PR DESCRIPTION
https://github.com/nfroidure/gulp-iconfont/issues/114#issuecomment-184569023 
https://github.com/nfroidure/gulp-iconfont/issues/105#issuecomment-184966024
Print warning  message when the font height is smaller than 1000. 