### PR TITLE
Filesorter: comparing filenames without their .svg extension

### DIFF
--- a/src/filesorter.js
+++ b/src/filesorter.js
@@ -9,7 +9,8 @@ function fileSorter(fileA, fileB) {
 
   if(testExpression.test(fileA)) {
     if(testExpression.test(fileB)) {
-      if(fileA < fileB) {
+      // Compare filenames without their .svg extension
+      if(fileA.substring(0, fileA.length - 4) < fileB.substring(0, fileB.length - 4)) {
         result = -1;
       } else {
         result = 1;
@@ -19,7 +20,7 @@ function fileSorter(fileA, fileB) {
     }
   } else if(testExpression.test(fileB)) {
     result = 1;
-  } else if(fileA < fileB) {
+  } else if(fileA.substring(0, fileA.length - 4) < fileB.substring(0, fileB.length - 4)) {
     result = -1;
   } else {
     result = 1;

--- a/tests/filesorter.mocha.js
+++ b/tests/filesorter.mocha.js
@@ -77,8 +77,8 @@ describe('fileSorter', () => {
       'uEA04-bookmark-favorite.svg',
       'uEA05-bookmark-o.svg',
       'uEA06-bookmark.svg',
-      'bell-disabled-o.svg',
       'bell-disabled.svg',
+      'bell-disabled-o.svg',
       'bell-o.svg',
     ]);
   });


### PR DESCRIPTION
Hi,

here's a minor PR about the sort order of SVG files that may or may not interest you 😃 

### Proposed changes
- Sort SVG files without their `.svg` extension so **`bell-disabled.svg` now comes before `bell-disabled-o.svg`**.  
It didn't because `-` comes before `.` in ASCII thus Unicode.  
Unmodified sorts: `Uxxxx-z.svg` still comes before `A.svg`, same for `Z.svg` and `a.svg`
- Test for my change already exists; I updated the expected result to reflect the modification described above  
Tests for sorts that shouldn't be modified by this modification already exist too

I tested another modification:

    if(fileA.substring(0, fileA.length - 4).localeCompare(fileB.substring(0, fileB.length - 4), "en", {sensitivity: 'variant', numeric: "true"}) < 0)

but with this test, the result is: `A < a < B < b < C` which I don't really care because I avoid uppercase in the name of SVG files and I don't really need a numerical sort `1 < 2 < 10` with SVG files...  
It may interest somebody reading this though 😉 

<!-- Check the boxes with a `x` like so `[x]` -->

### Code quality
- [ ] I made some tests for my changes
- [ ] I added my name in the
 [contributors](https://docs.npmjs.com/files/package.json#people-fields-author-contributors)
 field of the package.json file
- [x] I edited an existing test for my change

### License
To get your contribution merged, you must check the following.

- [x] I read the project license in the LICENSE file
- [x] I agree with publishing under this project license
