### PR TITLE
fix: Fixed issue with NaN in path attribute for some SVG

### DIFF
--- a/src/svgshapes2svgpath.js
+++ b/src/svgshapes2svgpath.js
@@ -24,7 +24,7 @@ function svgShapesToPathRectToPath(attributes) {
   const rx =
     'undefined' !== typeof attributes.rx ? parseFloat(attributes.rx) : 0;
   const ry =
-    'undefined' !== typeof attributes.ry ? parseFloat(attributes.ry) : 0;
+    'undefined' !== typeof attributes.ry ? parseFloat(attributes.ry) : rx;
 
   return (
     '' +

--- a/src/svgshapes2svgpath.js
+++ b/src/svgshapes2svgpath.js
@@ -22,7 +22,9 @@ function svgShapesToPathRectToPath(attributes) {
       ? parseFloat(attributes.height)
       : 0;
   const rx =
-    'undefined' !== typeof attributes.rx ? parseFloat(attributes.rx) : 0;
+    'undefined' !== typeof attributes.rx
+      ? parseFloat(attributes.rx)
+      : 'undefined' !== typeof attributes.ry ? parseFloat(attributes.ry) : 0;
   const ry =
     'undefined' !== typeof attributes.ry ? parseFloat(attributes.ry) : rx;
 

--- a/tests/expected/onlywithrx.svg
+++ b/tests/expected/onlywithrx.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<svg xmlns="http://www.w3.org/2000/svg">
+<defs>
+  <font id="onlywithrx" horiz-adv-x="500">
+    <font-face font-family="onlywithrx"
+      units-per-em="500" ascent="500"
+      descent="0" />
+    <missing-glyph horiz-adv-x="0" />
+    <glyph glyph-name="rounded"
+      unicode="&#xE001;"
+      horiz-adv-x="500" d="M139.1 499.56H477.51A22.49 22.49 0 0 0 500 477.07V140.42A22.49 22.49 0 0 0 477.51 117.93H139.1A22.49 22.49 0 0 0 116.61 140.42V477.07A22.49 22.49 0 0 0 139.1 499.56zM23.31 396.21A23.31 23.31 0 0 1 0 372.9V23.78A23.339999999999996 23.339999999999996 0 0 1 23.34 0.44H436.94A23.31 23.31 0 0 1 460.25 23.75V49.93H61.69A12.23 12.23 0 0 0 49.46 62.16V396.16z" />
+  </font>
+</defs>
+</svg>

--- a/tests/expected/onlywithry.svg
+++ b/tests/expected/onlywithry.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<svg xmlns="http://www.w3.org/2000/svg">
+<defs>
+  <font id="onlywithry" horiz-adv-x="500">
+    <font-face font-family="onlywithry"
+      units-per-em="500" ascent="500"
+      descent="0" />
+    <missing-glyph horiz-adv-x="0" />
+    <glyph glyph-name="rounded"
+      unicode="&#xE001;"
+      horiz-adv-x="500" d="M139.1 499.56H477.51A22.49 22.49 0 0 0 500 477.07V140.42A22.49 22.49 0 0 0 477.51 117.93H139.1A22.49 22.49 0 0 0 116.61 140.42V477.07A22.49 22.49 0 0 0 139.1 499.56zM23.31 396.21A23.31 23.31 0 0 1 0 372.9V23.78A23.339999999999996 23.339999999999996 0 0 1 23.34 0.44H436.94A23.31 23.31 0 0 1 460.25 23.75V49.93H61.69A12.23 12.23 0 0 0 49.46 62.16V396.16z" />
+  </font>
+</defs>
+</svg>

--- a/tests/fixtures/onlywithrx/rounded.svg
+++ b/tests/fixtures/onlywithrx/rounded.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500">
+    <title>icon-call-window-front</title>
+    <g id="g816">
+        <rect id="rect950" x="116.61" y="0.44" width="383.39" height="381.63" rx="22.49"/>
+        <path id="rect950-9"
+              d="M23.31,103.79A23.31,23.31,0,0,0,0,127.1V476.22a23.34,23.34,0,0,0,23.34,23.34h413.6a23.31,23.31,0,0,0,23.31-23.31V450.07H61.69a12.23,12.23,0,0,1-12.23-12.23v-334Z"/>
+    </g>
+</svg>

--- a/tests/fixtures/onlywithry/rounded.svg
+++ b/tests/fixtures/onlywithry/rounded.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500">
+    <title>icon-call-window-front</title>
+    <g id="g816">
+        <rect id="rect950" x="116.61" y="0.44" width="383.39" height="381.63" ry="22.49"/>
+        <path id="rect950-9"
+              d="M23.31,103.79A23.31,23.31,0,0,0,0,127.1V476.22a23.34,23.34,0,0,0,23.34,23.34h413.6a23.31,23.31,0,0,0,23.31-23.31V450.07H61.69a12.23,12.23,0,0,1-12.23-12.23v-334Z"/>
+    </g>
+</svg>

--- a/tests/index.mocha.js
+++ b/tests/index.mocha.js
@@ -403,6 +403,15 @@ describe('Generating fonts to files', () => {
       done
     );
   });
+
+  it('should work when only ry is present', done => {
+    generateFontToFile(
+      {
+        fontName: 'onlywithry',
+      },
+      done
+    );
+  });
 });
 
 describe('Generating fonts to memory', () => {

--- a/tests/index.mocha.js
+++ b/tests/index.mocha.js
@@ -394,6 +394,15 @@ describe('Generating fonts to files', () => {
       done
     );
   });
+
+  it('should work when only rx is present', done => {
+    generateFontToFile(
+      {
+        fontName: 'onlywithrx',
+      },
+      done
+    );
+  });
 });
 
 describe('Generating fonts to memory', () => {

--- a/tests/results/onlywithrx.svg
+++ b/tests/results/onlywithrx.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<svg xmlns="http://www.w3.org/2000/svg">
+<defs>
+  <font id="onlywithrx" horiz-adv-x="500">
+    <font-face font-family="onlywithrx"
+      units-per-em="500" ascent="500"
+      descent="0" />
+    <missing-glyph horiz-adv-x="0" />
+    <glyph glyph-name="rounded"
+      unicode="&#xE001;"
+      horiz-adv-x="500" d="M139.1 499.56H477.51A22.49 22.49 0 0 0 500 477.07V140.42A22.49 22.49 0 0 0 477.51 117.93H139.1A22.49 22.49 0 0 0 116.61 140.42V477.07A22.49 22.49 0 0 0 139.1 499.56zM23.31 396.21A23.31 23.31 0 0 1 0 372.9V23.78A23.339999999999996 23.339999999999996 0 0 1 23.34 0.44H436.94A23.31 23.31 0 0 1 460.25 23.75V49.93H61.69A12.23 12.23 0 0 0 49.46 62.16V396.16z" />
+  </font>
+</defs>
+</svg>

--- a/tests/results/onlywithry.svg
+++ b/tests/results/onlywithry.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<svg xmlns="http://www.w3.org/2000/svg">
+<defs>
+  <font id="onlywithry" horiz-adv-x="500">
+    <font-face font-family="onlywithry"
+      units-per-em="500" ascent="500"
+      descent="0" />
+    <missing-glyph horiz-adv-x="0" />
+    <glyph glyph-name="rounded"
+      unicode="&#xE001;"
+      horiz-adv-x="500" d="M139.1 499.56H477.51A22.49 22.49 0 0 0 500 477.07V140.42A22.49 22.49 0 0 0 477.51 117.93H139.1A22.49 22.49 0 0 0 116.61 140.42V477.07A22.49 22.49 0 0 0 139.1 499.56zM23.31 396.21A23.31 23.31 0 0 1 0 372.9V23.78A23.339999999999996 23.339999999999996 0 0 1 23.34 0.44H436.94A23.31 23.31 0 0 1 460.25 23.75V49.93H61.69A12.23 12.23 0 0 0 49.46 62.16V396.16z" />
+  </font>
+</defs>
+</svg>


### PR DESCRIPTION
### Proposed changes
- Fixed an issue transformation to path

*Original svg:*
```svg
<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500"><title>icon-call-window-front</title><g id="g816"><rect id="rect950" x="116.61" y="0.44" width="383.39" height="381.63" rx="22.49"/><path id="rect950-9" d="M23.31,103.79A23.31,23.31,0,0,0,0,127.1V476.22a23.34,23.34,0,0,0,23.34,23.34h413.6a23.31,23.31,0,0,0,23.31-23.31V450.07H61.69a12.23,12.23,0,0,1-12.23-12.23v-334Z"/></g></svg>
```

*Current result of transformation:*
```svg
<?xml version="1.0" standalone="no"?>
<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
<svg xmlns="http://www.w3.org/2000/svg">
<defs>
  <font id="iconfont" horiz-adv-x="500">
    <font-face font-family="iconfont"
      units-per-em="500" ascent="500"
      descent="0" />
    <missing-glyph horiz-adv-x="0" />
    <glyph glyph-name="icon-call-window-front"
      unicode="&#xEA01;"
      horiz-adv-x="500" d="M139.1 499.56H477.51ANaN NaN NaN 0 0 500 499.56V117.93ANaN NaN NaN 0 0 477.51 117.93H139.1ANaN NaN NaN 0 0 116.61 117.93V499.56ANaN NaN NaN 0 0 139.1 499.56zM23.31 396.21A23.31 23.31 0 0 1 0 372.9V23.78A23.339999999999996 23.339999999999996 0 0 1 23.34 0.44H436.94A23.31 23.31 0 0 1 460.25 23.75V49.93H61.69A12.23 12.23 0 0 0 49.46 62.16V396.1600000000001z" />
  </font>
</defs>
</svg>
```

*After this PR:*
```svg
<?xml version="1.0" standalone="no"?>
<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
<svg xmlns="http://www.w3.org/2000/svg">
<defs>
  <font id="iconfont" horiz-adv-x="500">
    <font-face font-family="iconfont"
      units-per-em="500" ascent="500"
      descent="0" />
    <missing-glyph horiz-adv-x="0" />
    <glyph glyph-name="icon-call-window-front"
      unicode="&#xEA01;"
      horiz-adv-x="500" d="M139.1 499.56H477.51A22.49 22.49 0 0 0 500 477.07V140.42A22.49 22.49 0 0 0 477.51 117.93H139.1A22.49 22.49 0 0 0 116.61 140.42V477.07A22.49 22.49 0 0 0 139.1 499.56zM23.31 396.21A23.31 23.31 0 0 1 0 372.9V23.78A23.339999999999996 23.339999999999996 0 0 1 23.34 0.44H436.94A23.31 23.31 0 0 1 460.25 23.75V49.93H61.69A12.23 12.23 0 0 0 49.46 62.16V396.1600000000001z" />
  </font>
</defs>
</svg>
```

### Code quality
- [x] I made some tests for my changes
- [ ] I added my name in the
 [contributors](https://docs.npmjs.com/files/package.json#people-fields-author-contributors)
 field of the package.json file

### License
To get your contribution merged, you must check the following.

- [x] I read the project license in the LICENSE file
- [x] I agree with publishing under this project license
