### PR TITLE
bump required node version in package.json, remove node 10 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,5 @@
 
 language: node_js
 node_js:
-  - 10
   - 12.14.0
   - 13

--- a/package.json
+++ b/package.json
@@ -43,8 +43,9 @@
     "fonts"
   ],
   "engines": {
-    "node": ">=6.9.5"
+    "node": ">=12.14.0"
   },
+  "engineStrict": true,
   "dependencies": {
     "commander": "^4.0.1",
     "geometry-interfaces": "^1.1.4",


### PR DESCRIPTION
this is a followup to #105 

[travis ci task](https://travis-ci.com/jaeh/svgicons2svgfont/builds/143597537) passes,
node 10 is removed,
npm install will error if node version is < 12.14.0