### PR TITLE
Add centerVertically option

### DIFF
--- a/.readme/contents.md
+++ b/.readme/contents.md
@@ -86,6 +86,7 @@ svgicons2svgfont --help
 #    -we, --weight [value]       the font weight you want
 #    -w, --fixedWidth            creates a monospace font of the width of the largest input icon
 #    -c, --centerhorizontally    calculate the bounds of a glyph and center it horizontally
+#    -y, --centervertically      centers the glyphs vertically in the generated font.
 #    -n, --normalize             normalize icons by scaling them to the height of the highest icon
 #    -h, --height [value]        the output font height [MAX(icons.height)] (icons will be scaled so the highest has this height)
 #    -r, --round [value]         setup the SVG path rounding [10e12]
@@ -136,6 +137,12 @@ Type: `Boolean`
 Default value: `false`
 
 Calculate the bounds of a glyph and center it horizontally.
+
+#### options.centerVertically
+Type: `Boolean`
+Default value: `false`
+
+Centers the glyphs vertically in the generated font.
 
 #### options.normalize
 Type: `Boolean`

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ svgicons2svgfont --help
 #    -we, --weight [value]       the font weight you want
 #    -w, --fixedWidth            creates a monospace font of the width of the largest input icon
 #    -c, --centerhorizontally    calculate the bounds of a glyph and center it horizontally
+#    -y, --centervertically      centers the glyphs vertically in the generated font.
 #    -n, --normalize             normalize icons by scaling them to the height of the highest icon
 #    -h, --height [value]        the output font height [MAX(icons.height)] (icons will be scaled so the highest has this height)
 #    -r, --round [value]         setup the SVG path rounding [10e12]
@@ -152,6 +153,12 @@ Type: `Boolean`
 Default value: `false`
 
 Calculate the bounds of a glyph and center it horizontally.
+
+#### options.centerVertically
+Type: `Boolean`
+Default value: `false`
+
+Centers the glyphs vertically in the generated font.
 
 #### options.normalize
 Type: `Boolean`

--- a/bin/svgicons2svgfont.js
+++ b/bin/svgicons2svgfont.js
@@ -28,6 +28,10 @@ program
     'calculate the bounds of a glyph and center it horizontally'
   )
   .option(
+    '-y, --centerVertically',
+    'centers the glyphs vertically in the generated font.'
+  )
+  .option(
     '-n, --normalize',
     'normalize icons by scaling them to the height of the highest icon'
   )
@@ -78,6 +82,7 @@ new SVGIconsDirStream(files, {
       fontId: program.fontId,
       fixedWidth: program.fixedwidth,
       centerHorizontally: program.centerHorizontally,
+      centerVertically: program.centerVertically,
       normalize: program.normalize,
       fontHeight: program.height,
       round: program.round,

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
   },
   "author": "Nicolas Froidure",
   "contributors": [
-    "Adrian Leonhard <adrianleonhard@gmail.com> (https://github.com/NaridaL)"
+    "Adrian Leonhard <adrianleonhard@gmail.com> (https://github.com/NaridaL)",
+    "Vinicius Teixeira <vinicius0026@gmail.com> (https://github.com/vinicius0026"
   ],
   "license": "MIT",
   "bugs": {

--- a/src/index.js
+++ b/src/index.js
@@ -476,15 +476,14 @@ class SVGIcons2SVGFontStream extends Transform {
           ...path.toAbs().matrix(...glyphPathTransform.toArray()).commands
         );
       });
-      if (this._options.centerHorizontally) {
-        const bounds = glyphPath.getBounds();
-
+      const bounds = (this._options.centerHorizontally || this._options.centerVertically) && glyphPath.getBounds();
+      if (this._options.centerHorizontally) { 
         glyphPath.translate(
           (glyph.width - (bounds.maxX - bounds.minX)) / 2 - bounds.minX
         );
       }
       if (this._options.centerVertically) {
-        glyphPath.translate(0, (fontHeight - glyph.height)/2)
+        glyphPath.translate(0, (fontHeight - (bounds.maxY - bounds.minY))/2)
       }
       delete glyph.paths;
       glyph.unicode.forEach((unicode, i) => {

--- a/src/index.js
+++ b/src/index.js
@@ -483,6 +483,9 @@ class SVGIcons2SVGFontStream extends Transform {
           (glyph.width - (bounds.maxX - bounds.minX)) / 2 - bounds.minX
         );
       }
+      if (this._options.centerVertically) {
+        glyphPath.translate(0, (fontHeight - glyph.height)/2)
+      }
       delete glyph.paths;
       glyph.unicode.forEach((unicode, i) => {
         const unicodeStr = ucs2

--- a/tests/expected/toverticalcentericons.svg
+++ b/tests/expected/toverticalcentericons.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<svg xmlns="http://www.w3.org/2000/svg">
+<defs>
+  <font id="toverticalcentericons" horiz-adv-x="100">
+    <font-face font-family="toverticalcentericons"
+      units-per-em="100" ascent="100"
+      descent="0" />
+    <missing-glyph horiz-adv-x="0" />
+    <glyph glyph-name="bottomleft"
+      unicode="&#xE001;"
+      horiz-adv-x="100" d="M20 20L20 40L40 40L40 20z" />
+    <glyph glyph-name="center"
+      unicode="&#xE002;"
+      horiz-adv-x="100" d="M40 40L40 60L60 60L60 40z" />
+    <glyph glyph-name="topright"
+      unicode="&#xE003;"
+      horiz-adv-x="100" d="M60 80L60 60L80 60L80 80z" />
+  </font>
+</defs>
+</svg>

--- a/tests/fixtures/toverticalcentericons/bottomleft.svg
+++ b/tests/fixtures/toverticalcentericons/bottomleft.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="100"
+   height="100"
+   viewBox="0 0 100 100">
+  <polygon
+     points="20,80 20,60 40,60 40,80" />
+</svg>

--- a/tests/fixtures/toverticalcentericons/center.svg
+++ b/tests/fixtures/toverticalcentericons/center.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="100"
+   height="100"
+   viewBox="0 0 100 100">
+  <polygon
+     points="40,60 40,40 60,40 60,60" />
+</svg>

--- a/tests/fixtures/toverticalcentericons/topright.svg
+++ b/tests/fixtures/toverticalcentericons/topright.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="100"
+   height="100"
+   viewBox="0 0 100 100">
+  <polygon
+     points="60,20 60,40 80,40 80,20" />
+</svg>

--- a/tests/index.mocha.js
+++ b/tests/index.mocha.js
@@ -292,6 +292,16 @@ describe('Generating fonts to files', () => {
     );
   });
 
+  it('should work when vertically centering SVG icons', done => {
+    generateFontToFile(
+      {
+        fontName: 'toverticalcentericons',
+        centerVertically: true,
+      },
+      done
+    );
+  });
+
   it('should work with a icons with path with fill none', done => {
     generateFontToFile(
       {

--- a/tests/results/toverticalcentericons.svg
+++ b/tests/results/toverticalcentericons.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<svg xmlns="http://www.w3.org/2000/svg">
+<defs>
+  <font id="toverticalcentericons" horiz-adv-x="100">
+    <font-face font-family="toverticalcentericons"
+      units-per-em="100" ascent="100"
+      descent="0" />
+    <missing-glyph horiz-adv-x="0" />
+    <glyph glyph-name="bottomleft"
+      unicode="&#xE001;"
+      horiz-adv-x="100" d="M20 20L20 40L40 40L40 20z" />
+    <glyph glyph-name="center"
+      unicode="&#xE002;"
+      horiz-adv-x="100" d="M40 40L40 60L60 60L60 40z" />
+    <glyph glyph-name="topright"
+      unicode="&#xE003;"
+      horiz-adv-x="100" d="M60 80L60 60L80 60L80 80z" />
+  </font>
+</defs>
+</svg>


### PR DESCRIPTION
Fixes #120 

### Proposed changes
- add `centerVertically` option to center glyphs vertically in the generated font


<!-- Check the boxes with a `x` like so `[x]` -->

### Code quality
- [x] I made some tests for my changes
- [x] I added my name in the
 [contributors](https://docs.npmjs.com/files/package.json#people-fields-author-contributors)
 field of the package.json file

### License
To get your contribution merged, you must check the following.

- [x] I read the project license in the LICENSE file
- [x] I agree with publishing under this project license

