### PR TITLE
Fix calculation for vertical centering

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -477,13 +477,13 @@ class SVGIcons2SVGFontStream extends Transform {
         );
       });
       const bounds = (this._options.centerHorizontally || this._options.centerVertically) && glyphPath.getBounds();
-      if (this._options.centerHorizontally) { 
+      if (this._options.centerHorizontally) {
         glyphPath.translate(
           (glyph.width - (bounds.maxX - bounds.minX)) / 2 - bounds.minX
         );
       }
       if (this._options.centerVertically) {
-        glyphPath.translate(0, (fontHeight - (bounds.maxY - bounds.minY))/2)
+        glyphPath.translate(0, (fontHeight - (bounds.maxY - bounds.minY))/2 - bounds.minY)
       }
       delete glyph.paths;
       glyph.unicode.forEach((unicode, i) => {

--- a/tests/expected/toverticalcentericons.svg
+++ b/tests/expected/toverticalcentericons.svg
@@ -9,13 +9,13 @@
     <missing-glyph horiz-adv-x="0" />
     <glyph glyph-name="bottomleft"
       unicode="&#xE001;"
-      horiz-adv-x="100" d="M20 20L20 40L40 40L40 20z" />
+      horiz-adv-x="100" d="M20 40L20 60L40 60L40 40z" />
     <glyph glyph-name="center"
       unicode="&#xE002;"
       horiz-adv-x="100" d="M40 40L40 60L60 60L60 40z" />
     <glyph glyph-name="topright"
       unicode="&#xE003;"
-      horiz-adv-x="100" d="M60 80L60 60L80 60L80 80z" />
+      horiz-adv-x="100" d="M60 60L60 40L80 40L80 60z" />
   </font>
 </defs>
 </svg>

--- a/tests/results/toverticalcentericons.svg
+++ b/tests/results/toverticalcentericons.svg
@@ -9,13 +9,13 @@
     <missing-glyph horiz-adv-x="0" />
     <glyph glyph-name="bottomleft"
       unicode="&#xE001;"
-      horiz-adv-x="100" d="M20 20L20 40L40 40L40 20z" />
+      horiz-adv-x="100" d="M20 40L20 60L40 60L40 40z" />
     <glyph glyph-name="center"
       unicode="&#xE002;"
       horiz-adv-x="100" d="M40 40L40 60L60 60L60 40z" />
     <glyph glyph-name="topright"
       unicode="&#xE003;"
-      horiz-adv-x="100" d="M60 80L60 60L80 60L80 80z" />
+      horiz-adv-x="100" d="M60 60L60 40L80 40L80 60z" />
   </font>
 </defs>
 </svg>


### PR DESCRIPTION
Fixing bug introduced in https://github.com/nfroidure/svgicons2svgfont/pull/119. Resolving https://github.com/nfroidure/svgicons2svgfont/issues/120.

Previous paths:
![image](https://user-images.githubusercontent.com/3654180/115958714-10e48f80-a53b-11eb-9c36-09836d855ad6.png)

New paths:
![image](https://user-images.githubusercontent.com/3654180/115958611-b64b3380-a53a-11eb-8c49-da354a8e2938.png)
