### PR TITLE
Compute glyph path only once per glyph

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -475,12 +475,12 @@ class SVGIcons2SVGFontStream extends Transform {
         );
       }
       delete glyph.paths;
+      const d = glyphPath.round(this._options.round).encode();
       glyph.unicode.forEach((unicode, i) => {
         const unicodeStr = ucs2
           .decode(unicode)
           .map((point) => '&#x' + point.toString(16).toUpperCase() + ';')
           .join('');
-        const d = glyphPath.round(this._options.round).encode();
 
         this.push(
           '    <glyph glyph-name="' +


### PR DESCRIPTION
<!--

Thanks for improving this project!

Before doing so, there are a few checks to do in
 order to get your PR merged asap. Just fill in the
 following template.

-->

Fixes #133 

### Proposed changes

Previously, we run `glyphPath.round()` multiple times for multiple codepoints. Since `glyphPath` is mutable, there's a chance for rounding and precision errors to accumulate, causing the computed path to vary for the same glyph. See #133 for details.

Now, we compute the glyph's path only once, using that for each unicode codepoint.

<!-- Check the boxes with a `x` like so `[x]` -->

### Code quality

I did not include an explicit test for this change. As a minor optimization that happens to fix the linked issue, it is a little difficult to test, IMO, without arbitrarily specific icons and configuration. I'd be happy to add this if the maintainers think it would be useful in the long run.

### License
To get your contribution merged, you must check the following.

- [x] I read the project license in the LICENSE file
- [x] I agree with publishing under this project license

<!--

If you already maintain several NPM modules / NodeJS
 project, making significant changes on one of my modules
 automatically legitimates you as a core developer.

This is because i could die or even not give a shit to
 this project someday and i don't want people to get
 stuck.

If you want to help, fill the following with to get
GitHub/NPM r/w access.

-->
### Join
- [ ] I wish to join the core team
- [ ] I agree that with great powers comes responsibilities
- [ ] I'm a nice person

My NPM username:
