### PR TITLE
Fix normalize option with wide icons

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -433,7 +433,7 @@ class SVGIcons2SVGFontStream extends Transform {
 
     this.glyphs.forEach((glyph) => {
       const ratio = this._options.normalize
-        ? fontHeight / glyph.height
+        ? fontHeight / (glyph.width > glyph.height ? glyph.width : glyph.height)
         : fontHeight / maxGlyphHeight;
       if (!isFinite(ratio)) throw new Error('foo');
       glyph.width *= ratio;

--- a/tests/expected/variableheighticonsn.svg
+++ b/tests/expected/variableheighticonsn.svg
@@ -9,7 +9,7 @@
     <missing-glyph horiz-adv-x="0" />
     <glyph glyph-name="arrow-down"
       unicode="&#xE001;"
-      horiz-adv-x="225" d="M112.5 45L180 120L45 120z" />
+      horiz-adv-x="150" d="M75 30L120 80L30 80z" />
     <glyph glyph-name="arrow-left"
       unicode="&#xE002;"
       horiz-adv-x="150" d="M50 75L100 120L100 30z" />
@@ -18,7 +18,7 @@
       horiz-adv-x="150" d="M100 75L50 120L50 30z" />
     <glyph glyph-name="arrow-up"
       unicode="&#xE004;"
-      horiz-adv-x="225" d="M112.5 120L180 45L45 45z" />
+      horiz-adv-x="150" d="M75 80L120 30L30 30z" />
   </font>
 </defs>
 </svg>

--- a/tests/results/variableheighticonsn.svg
+++ b/tests/results/variableheighticonsn.svg
@@ -9,7 +9,7 @@
     <missing-glyph horiz-adv-x="0" />
     <glyph glyph-name="arrow-down"
       unicode="&#xE001;"
-      horiz-adv-x="225" d="M112.5 45L180 120L45 120z" />
+      horiz-adv-x="150" d="M75 30L120 80L30 80z" />
     <glyph glyph-name="arrow-left"
       unicode="&#xE002;"
       horiz-adv-x="150" d="M50 75L100 120L100 30z" />
@@ -18,7 +18,7 @@
       horiz-adv-x="150" d="M100 75L50 120L50 30z" />
     <glyph glyph-name="arrow-up"
       unicode="&#xE004;"
-      horiz-adv-x="225" d="M112.5 120L180 45L45 45z" />
+      horiz-adv-x="150" d="M75 80L120 30L30 30z" />
   </font>
 </defs>
 </svg>


### PR DESCRIPTION
Fixes #112

### Proposed changes
Fix normalize option with wide icons

<!-- Check the boxes with a `x` like so `[x]` -->

### Code quality
- [X] I made some tests for my changes
- [ ] I added my name in the
 [contributors](https://docs.npmjs.com/files/package.json#people-fields-author-contributors)
 field of the package.json file

### License
To get your contribution merged, you must check the following.

- [X] I read the project license in the LICENSE file
- [X] I agree with publishing under this project license

### Join
- [ ] I wish to join the core team
- [ ] I agree that with great powers comes responsibilities
- [ ] I'm a nice person

My NPM username: ramirezcgn
