### PR TITLE
Fixed param name typo

### DIFF
--- a/bin/svgicons2svgfont.js
+++ b/bin/svgicons2svgfont.js
@@ -25,7 +25,7 @@ program
     'creates a monospace font of the width of the largest input icon'
   )
   .option(
-    '-c, --centerhorizontally',
+    '-c, --centerHorizontally',
     'calculate the bounds of a glyph and center it horizontally'
   )
   .option(


### PR DESCRIPTION
There is a typo setting horizontal center, the way it is it will never even attempt to center the glyph

This should be enough to fix it
