### PR TITLE
Replace node:punycode with punycode.js due to deprecate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "commander": "^12.1.0",
         "debug": "^4.3.6",
         "glob": "^11.0.0",
+        "punycode": "^2.3.1",
         "sax": "^1.4.1",
         "svg-pathdata": "^7.0.0",
         "transformation-matrix-js": "^2.7.6",
@@ -7148,7 +7149,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "commander": "^12.1.0",
     "debug": "^4.3.6",
     "glob": "^11.0.0",
+    "punycode": "^2.3.1",
     "sax": "^1.4.1",
     "svg-pathdata": "^7.0.0",
     "transformation-matrix-js": "^2.7.6",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { ucs2 } from 'punycode';
+import punycode from 'punycode/punycode.js';
 import { Transform } from 'stream';
 import Sax from 'sax';
 import { SVGPathData } from 'svg-pathdata';
@@ -562,7 +562,7 @@ export class SVGIcons2SVGFontStream extends Transform {
       delete glyph.paths;
       const d = glyphPath.round(this._options.round).encode();
       glyph.unicode.forEach((unicode, i) => {
-        const unicodeStr = ucs2
+        const unicodeStr = punycode.ucs2
           .decode(unicode)
           .map((point) => '&#x' + point.toString(16).toUpperCase() + ';')
           .join('');

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -4,7 +4,7 @@ import { Readable } from 'node:stream';
 import fs from 'node:fs';
 import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
-import { ucs2 as ucs2 } from 'punycode';
+import punycode from 'punycode/punycode.js';
 
 import { SVGIcons2SVGFontStream } from '../index.js';
 import { SVGIconsDirStream, type SVGIconStream } from '../iconsdir.js';
@@ -566,7 +566,7 @@ describe('Passing code points', () => {
 
     svgIconStream.metadata = {
       name: 'account',
-      unicode: [ucs2.encode([0x1f63a])],
+      unicode: [punycode.ucs2.encode([0x1f63a])],
     };
 
     const promise = bufferStream(svgFontStream);


### PR DESCRIPTION
Fixes #

Replacing node:punycode with punycode.js due to 
Ref: [https://nodejs.org/api/punycode.html](https://nodejs.org/api/punycode.html)

<!-- Check the boxes with a `x` like so `[x]` -->

### Code quality
- [ ] I made some tests for my changes
- [ ] I added my name in the
 [contributors](https://docs.npmjs.com/files/package.json#people-fields-author-contributors)
 field of the `package.json` file.

### License
To get your contribution merged, you must check the following.

- [x] I read the project license in the LICENSE file
- [x] I agree with publishing under this project license

### Join
- [ ] I wish to join the core team
- [ ] I agree that with great powers comes responsibilities
- [ ] I'm a nice person
