### PR TITLE
Replace punycode dependency with string iteration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "commander": "^12.1.0",
         "debug": "^4.3.6",
         "glob": "^11.0.0",
-        "punycode": "^2.3.1",
         "sax": "^1.4.1",
         "svg-pathdata": "^7.0.0",
         "transformation-matrix-js": "^2.7.6",
@@ -7149,6 +7148,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "commander": "^12.1.0",
     "debug": "^4.3.6",
     "glob": "^11.0.0",
-    "punycode": "^2.3.1",
     "sax": "^1.4.1",
     "svg-pathdata": "^7.0.0",
     "transformation-matrix-js": "^2.7.6",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import punycode from 'punycode/punycode.js';
 import { Transform } from 'stream';
 import Sax from 'sax';
 import { SVGPathData } from 'svg-pathdata';
@@ -562,9 +561,11 @@ export class SVGIcons2SVGFontStream extends Transform {
       delete glyph.paths;
       const d = glyphPath.round(this._options.round).encode();
       glyph.unicode.forEach((unicode, i) => {
-        const unicodeStr = punycode.ucs2
-          .decode(unicode)
-          .map((point) => '&#x' + point.toString(16).toUpperCase() + ';')
+        const unicodeStr = [...unicode]
+          .map(
+            (char) =>
+              '&#x' + char.codePointAt(0)!.toString(16).toUpperCase() + ';',
+          )
           .join('');
 
         this.push(

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -4,7 +4,6 @@ import { Readable } from 'node:stream';
 import fs from 'node:fs';
 import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
-import punycode from 'punycode/punycode.js';
 
 import { SVGIcons2SVGFontStream } from '../index.js';
 import { SVGIconsDirStream, type SVGIconStream } from '../iconsdir.js';
@@ -572,7 +571,7 @@ describe('Passing code points', () => {
 
     svgIconStream.metadata = {
       name: 'account',
-      unicode: [punycode.ucs2.encode([0x1f63a])],
+      unicode: ['\u{1f63a}'],
     };
 
     const promise = bufferStream(svgFontStream);


### PR DESCRIPTION
### Proposed changes

The spread operator has been available since Node 5.0.0, and iterates strings over their code points (not code units), as expected here. There’s no need to use the punycode library for this.

### Code quality
- [ ] I made some tests for my changes
  - This is already covered by tests
- [ ] I added my name in the  [contributors](https://docs.npmjs.com/files/package.json#people-fields-author-contributors) field of the `package.json` file. Beware to use the same format than for the author field for the entries so that you'll get a mention in the `README.md` with a link to your website.

### License
To get your contribution merged, you must check the following.

- [x] I read the project license in the LICENSE file
- [x] I agree with publishing under this project license

### Join
- [ ] I wish to join the core team
- [ ] I agree that with great powers comes responsibilities
- [ ] I'm a nice person

My NPM username: andersk
