### PR TITLE
feat(transformers): add path simplification and outline generation algorithms

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "prettier": "prettier --write 'src/**/*.ts'",
     "preversion": "npm run build && npm t && npm run lint && npm run metapak -- -s",
     "rebuild": "swc ./src -s -d dist -C jsc.target=es2022",
-    "test": "npm run jest",
+    "test": "npm run jest && npm run test:native",
+    "test:native": "node --experimental-strip-types --test ./src/transformers/*/*.test.ts",
     "type-check": "tsc --pretty --noEmit",
     "version": "npm run changelog"
   },

--- a/src/transformers/outline/math.ts
+++ b/src/transformers/outline/math.ts
@@ -1,0 +1,302 @@
+import type { Point } from "../utils/geometry.ts";
+import {
+  arePointsSame,
+  magnitude,
+  rotateVector,
+  perpendicularVector,
+  normalizeVector,
+  dotProduct,
+  createVector,
+  calculateRotation,
+  isNumberValid,
+  crossProduct,
+  scaleVector,
+} from "../utils/geometry.ts";
+
+/**
+ * Calculates the offset vector for standard corner points (non-curve endpoints)
+ * @param p1 Previous point
+ * @param p2 Current point (corner)
+ * @param p3 Next point
+ * @param distance Offset distance
+ * @returns The offset vector from the corner point
+ */
+export function calculateStandardCornerOffset(p1: Point, p2: Point, p3: Point, distance: number): Point {
+  // Handle identical points cases - if the point we're offsetting is identical to both neighbors
+  if (arePointsSame(p1, p2) && arePointsSame(p2, p3)) {
+    return { x: 0, y: 0 };
+  }
+
+  // Handle case where current point is identical to previous point
+  if (arePointsSame(p1, p2)) {
+    // For duplicate points, try to find another point in the path for better offset
+    // If P1=P2, then we need to create a synthetic previous point by reflecting P3
+    // This creates a virtual corner that will give a better offset direction
+    const syntheticP1 = { x: 2 * p2.x - p3.x, y: 2 * p2.y - p3.y };
+
+    // Now use this synthetic point with regular line intersection logic
+    return calculateCornerOffsetInternal(syntheticP1, p2, p3, distance);
+  }
+
+  // Handle case where current point is identical to next point
+  if (arePointsSame(p2, p3)) {
+    // For duplicate points, try to find another point in the path for better offset
+    // If P2=P3, then we need to create a synthetic next point by reflecting P1
+    // This creates a virtual corner that will give a better offset direction
+    const syntheticP3 = { x: 2 * p2.x - p1.x, y: 2 * p2.y - p1.y };
+
+    // Now use this synthetic point with regular line intersection logic
+    return calculateCornerOffsetInternal(p1, p2, syntheticP3, distance);
+  }
+
+  // Standard case - no identical points
+  return calculateCornerOffsetInternal(p1, p2, p3, distance);
+}
+
+/**
+ * Calculates offset vector specifically for curve endpoints using tangent information
+ * @param point The curve endpoint
+ * @param cp2 Incoming control point (can be null)
+ * @param cp1 Outgoing control point (can be null)
+ * @param distance Offset distance
+ * @returns The offset vector from the curve endpoint
+ */
+export function calculateCurveEndpointOffset(
+  point: Point,
+  cp2: Point | null,
+  cp1: Point | null,
+  distance: number,
+): Point {
+  // For a curve endpoint, use the curve's tangent direction instead of segment direction
+  let incomingDirection: Point | null = null;
+  let outgoingDirection: Point | null = null;
+
+  // Get the incoming direction (based on control point)
+  if (cp2 && !arePointsSame(cp2, point)) {
+    incomingDirection = normalizeVector(createVector(cp2, point));
+  }
+
+  // Get the outgoing direction (based on control point)
+  if (cp1 && !arePointsSame(cp1, point)) {
+    outgoingDirection = normalizeVector(createVector(point, cp1));
+  }
+
+  // If we have both directions, calculate offset using the intersections of perpendiculars
+  if (incomingDirection && outgoingDirection) {
+    const incomingPerp = perpendicularVector(incomingDirection, true);
+    const outgoingPerp = perpendicularVector(outgoingDirection, true);
+    return calculateCornerOffsetWithDirections(point, incomingPerp, outgoingPerp, distance);
+  }
+
+  // If we only have an incoming direction, use its perpendicular vector for the offset
+  if (incomingDirection) {
+    const perpVector = perpendicularVector(incomingDirection, true);
+    return scaleVector(perpVector, distance);
+  }
+
+  // If we only have an outgoing direction, use its perpendicular vector for the offset
+  if (outgoingDirection) {
+    const perpVector = perpendicularVector(outgoingDirection, true);
+    return scaleVector(perpVector, distance);
+  }
+
+  // Fallback if we don't have any tangent information
+  return { x: 0, y: 0 };
+}
+
+/**
+ * Internal function for corner offset calculation once we've handled special cases
+ */
+function calculateCornerOffsetInternal(p1: Point, p2: Point, p3: Point, distance: number): Point {
+  // Calculate direction normalized direction vectors between points
+  const vpNorm = normalizeVector(createVector(p1, p2)); // Previous segment
+  const vnNorm = normalizeVector(createVector(p2, p3)); // Next segment
+
+  // Calculate perpendicular normal vectors (pointing outward)
+  const npNorm = perpendicularVector(vpNorm, true);
+  const nnNorm = perpendicularVector(vnNorm, true);
+
+  // Special case: collinear segments with same direction (straight line)
+  const dotDirections = dotProduct(vpNorm, vnNorm);
+  if (Math.abs(dotDirections - 1) < 0.0001) {
+    return scaleVector(npNorm, distance);
+  }
+
+  // Special case: collinear segments with opposite direction (U-turn)
+  if (Math.abs(dotDirections + 1) < 0.0001) {
+    // Use perpendicular to one of the segments
+    return scaleVector(npNorm, distance);
+  }
+
+  // Calculate offset points
+  const offsetPoint1 = {
+    x: p2.x + distance * npNorm.x,
+    y: p2.y + distance * npNorm.y,
+  };
+
+  const offsetPoint2 = {
+    x: p2.x + distance * nnNorm.x,
+    y: p2.y + distance * nnNorm.y,
+  };
+
+  // Define lines using OFFSET points and ORIGINAL segment directions
+  // Line 1: Through offsetPoint1 in vpNorm direction
+  // Line 2: Through offsetPoint2 in vnNorm direction
+
+  // Line equations in parametric form:
+  // P1(t) = offsetPoint1 + t * vpNorm
+  // P2(s) = offsetPoint2 + s * vnNorm
+
+  // At intersection: P1(t) = P2(s)
+  // offsetPoint1 + t * vpNorm = offsetPoint2 + s * vnNorm
+
+  // This gives us:
+  // offsetPoint1.x + t * vpNorm.x = offsetPoint2.x + s * vnNorm.x
+  // offsetPoint1.y + t * vpNorm.y = offsetPoint2.y + s * vnNorm.y
+
+  // Cross-multiply to eliminate s:
+  const det = crossProduct(vpNorm, vnNorm);
+
+  // Check for parallel lines
+  if (Math.abs(det) < 0.0001) {
+    return {
+      x: (offsetPoint1.x + offsetPoint2.x) / 2 - p2.x,
+      y: (offsetPoint1.y + offsetPoint2.y) / 2 - p2.y,
+    };
+  }
+
+  // Solve for t
+  const dx = offsetPoint2.x - offsetPoint1.x;
+  const dy = offsetPoint2.y - offsetPoint1.y;
+
+  const t = (dx * vnNorm.y - dy * vnNorm.x) / det;
+
+  // Calculate intersection point
+  const intersection = {
+    x: offsetPoint1.x + t * vpNorm.x,
+    y: offsetPoint1.y + t * vpNorm.y,
+  };
+
+  // Calculate offset vector from original point to intersection
+  const offsetVector = createVector(p2, intersection);
+
+  // Safety check for invalid results
+  if (!isNumberValid(offsetVector.x) || !isNumberValid(offsetVector.y)) {
+    return {
+      x: (offsetPoint1.x + offsetPoint2.x) / 2 - p2.x,
+      y: (offsetPoint1.y + offsetPoint2.y) / 2 - p2.y,
+    };
+  }
+
+  return offsetVector;
+}
+
+/**
+ * Calculate corner offset using specific direction vectors instead of points
+ * @param p Point to offset
+ * @param incomingPerp Perpendicular vector to incoming direction
+ * @param outgoingPerp Perpendicular vector to outgoing direction
+ * @param distance Offset distance
+ * @returns The offset vector
+ */
+function calculateCornerOffsetWithDirections(
+  p: Point,
+  incomingPerp: Point,
+  outgoingPerp: Point,
+  distance: number,
+): Point {
+  // Calculate offset points along the perpendicular vectors
+  const scaledIncoming = scaleVector(incomingPerp, distance);
+  const scaledOutgoing = scaleVector(outgoingPerp, distance);
+
+  const offsetPoint1 = {
+    x: p.x + scaledIncoming.x,
+    y: p.y + scaledIncoming.y,
+  };
+
+  const offsetPoint2 = {
+    x: p.x + scaledOutgoing.x,
+    y: p.y + scaledOutgoing.y,
+  };
+
+  // Create artificial direction vectors for the line intersection calculation
+  // (perpendicular to the perpendicular = original direction)
+  const dir1 = perpendicularVector(incomingPerp, true);
+  const dir2 = perpendicularVector(outgoingPerp, true);
+
+  // Check for parallel directions
+  const det = crossProduct(dir1, dir2);
+  if (Math.abs(det) < 0.0001) {
+    return {
+      x: (offsetPoint1.x + offsetPoint2.x) / 2 - p.x,
+      y: (offsetPoint1.y + offsetPoint2.y) / 2 - p.y,
+    };
+  }
+
+  // Calculate intersection of offset lines
+  const dx = offsetPoint2.x - offsetPoint1.x;
+  const dy = offsetPoint2.y - offsetPoint1.y;
+  const t = (dx * dir2.y - dy * dir2.x) / det;
+
+  // Calculate intersection point and resulting offset vector
+  const intersection = {
+    x: offsetPoint1.x + t * dir1.x,
+    y: offsetPoint1.y + t * dir1.y,
+  };
+
+  const offsetVector = createVector(p, intersection);
+
+  return offsetVector;
+}
+
+/**
+ * Transforms Bézier curve control points to maintain curve appearance when endpoints are moved
+ * Uses vector-based transformation to preserve geometric relationships
+ *
+ * @param originalStartPoint Original curve start point
+ * @param originalControlPoint1 Original first control point
+ * @param originalControlPoint2 Original second control point
+ * @param originalEndPoint Original curve end point
+ * @param newStartPoint New curve start point
+ * @param newEndPoint New curve end point
+ * @returns The transformed control points
+ */
+export function transformControlPoints(
+  originalStartPoint: Point,
+  originalControlPoint1: Point,
+  originalControlPoint2: Point,
+  originalEndPoint: Point,
+  newStartPoint: Point,
+  newEndPoint: Point,
+): { controlPoint1: Point; controlPoint2: Point } {
+  // Vectors from endpoints to control points and baseline vectors
+  const origVec1 = createVector(originalStartPoint, originalControlPoint1);
+  const origVec2 = createVector(originalEndPoint, originalControlPoint2);
+  const origBaseline = createVector(originalStartPoint, originalEndPoint);
+  const newBaseline = createVector(newStartPoint, newEndPoint);
+
+  // Calculate rotation angle between original and new baseline
+  const rotation = calculateRotation(origBaseline, newBaseline);
+
+  // Calculate scale change
+  const origLength = magnitude(origBaseline);
+  const scale = origLength === 0 ? 1 : magnitude(newBaseline) / origLength;
+
+  // Transform control points using rotation and scaling
+  const rotatedVec1 = rotateVector(origVec1, rotation);
+  const rotatedVec2 = rotateVector(origVec2, rotation);
+
+  const scaledRotatedVec1 = scaleVector(rotatedVec1, scale);
+  const scaledRotatedVec2 = scaleVector(rotatedVec2, scale);
+
+  return {
+    controlPoint1: {
+      x: newStartPoint.x + scaledRotatedVec1.x,
+      y: newStartPoint.y + scaledRotatedVec1.y,
+    },
+    controlPoint2: {
+      x: newEndPoint.x + scaledRotatedVec2.x,
+      y: newEndPoint.y + scaledRotatedVec2.y,
+    },
+  };
+}

--- a/src/transformers/outline/outline.md
+++ b/src/transformers/outline/outline.md
@@ -1,0 +1,41 @@
+# Path Outline Generation
+
+Algorithm for generating outlines around SVG paths with consistent thickness.
+
+## Path Types
+
+- **Explicitly Closed Paths**: End with CLOSE_PATH command
+- **Implicitly Closed Paths**: Have identical start/end points, but no
+  CLOSE_PATH command
+- **Open Paths**: Have different start and end points
+
+## Approach
+
+### Closed Paths
+
+1. Remove CLOSE_PATH command (if present)
+2. Apply offset to each point by specified distance
+3. Re-add CLOSE_PATH command
+
+### Open Paths
+
+1. Create a reversed copy of the original path
+2. Connect original path with reversed path
+3. Apply offset with half the distance
+4. Close the shape with CLOSE_PATH
+
+## Point Offset Calculation
+
+- **Corner Points**: Use line intersection method for mitered joins
+- **Curve Endpoints**: Use tangent-based calculation
+- **Special Cases**:
+  - Collinear points: Use perpendicular offset
+  - Identical points: Create synthetic points to form meaningful angles
+
+## Curve Transformation
+
+For Bézier curves:
+
+- Offset endpoints using tangent information
+- Transform control points maintaining tangent directions
+- Create approximation of equidistant curve

--- a/src/transformers/outline/outline.test.ts
+++ b/src/transformers/outline/outline.test.ts
@@ -1,0 +1,273 @@
+import { test, describe } from "node:test";
+import { strictEqual } from "node:assert";
+
+import { SVGPathData } from "svg-pathdata";
+
+import { OUTLINE } from "./outline.ts";
+
+function runOutline(path: string, distance: number): string {
+  const pathData = new SVGPathData(path).toAbs();
+  pathData.commands = OUTLINE(distance, pathData.commands);
+  return pathData.round(1000).encode();
+}
+
+/**
+ * Helper to normalize the path string by removing extra spaces
+ * and normalizing path command formatting
+ */
+function normalizePath(path: string): string {
+  // Use the direct round method with 1000 as the factor (3 decimal places)
+  return new SVGPathData(path).toAbs().round(1000).encode();
+}
+
+describe("Outline generation", () => {
+  describe("Closed paths", () => {
+    describe("Rectangles", () => {
+      test("Rectangle with distance = 1", () => {
+        const input = "M20,10 L150,10 L150,40 L20,40 Z";
+        const expected = "M19.5 9.5L150.5 9.5L150.5 40.5L19.5 40.5M20.5 39.5L149.5 39.5L149.5 10.5L20.5 10.5z";
+        strictEqual(runOutline(input, 1), expected);
+      });
+
+      test("Rectangle with distance = 3", () => {
+        const input = "M20,50 L150,50 L150,80 L20,80 Z";
+        const expected = "M18.5 48.5L151.5 48.5L151.5 81.5L18.5 81.5M21.5 78.5L148.5 78.5L148.5 51.5L21.5 51.5z";
+        strictEqual(runOutline(input, 3), expected);
+      });
+
+      test("Rectangle with distance = 10", () => {
+        const input = "M20,100 L150,100 L150,130 L20,130 Z";
+        const expected = "M15 95L155 95L155 135L15 135M25 125L145 125L145 105L25 105z";
+        strictEqual(runOutline(input, 10), expected);
+      });
+
+      test("Implicitly closed rectangle", () => {
+        const input = "M20,20 L60,20 L60,60 L20,60 L20,20";
+        const expected = "M19 19L61 19L61 61L19 61L19 19M21 21L21 59L59 59L59 21L21 21z";
+        strictEqual(runOutline(input, 2), normalizePath(expected));
+      });
+    });
+
+    describe("Triangles", () => {
+      test("Triangle with distance = 1", () => {
+        const input = "M75 120L120 70L30 70z";
+        const expected = "M75 119.253L118.877 70.5L31.123 70.5M28.877 69.5L121.123 69.5L75 120.747z";
+        strictEqual(runOutline(input, 1), expected);
+      });
+
+      test("Triangle with distance = 2", () => {
+        const input = "M75 240L120 190L30 190z";
+        const expected = "M75 238.505L117.755 191L32.245 191M27.755 189L122.245 189L75 241.495z";
+        strictEqual(runOutline(input, 2), expected);
+      });
+
+      test("Triangle with distance = 10", () => {
+        const input = "M75 300L120 250L30 250z";
+        const expected = "M75 292.526L108.773 255L41.227 255M18.773 245L131.227 245L75 307.474z";
+        strictEqual(runOutline(input, 10), expected);
+      });
+    });
+
+    describe("Circles", () => {
+      test("Circle with distance = 1", () => {
+        const input =
+          "M8 5C8 6.656854249493 6.656854249493 8 5 8C3.343145750507 8 2 6.656854249493 2 5C2 3.343145750507 3.343145750507 2 5 2C6.656854249493 2 8 3.343145750507 8 5z";
+        const expected =
+          "M8.5 5C8.5 6.933 6.933 8.5 5 8.5C3.067 8.5 1.5 6.933 1.5 5C1.5 3.067 3.067 1.5 5 1.5C6.933 1.5 8.5 3.067 8.5 5M7.5 5C7.5 3.619 6.381 2.5 5 2.5C3.619 2.5 2.5 3.619 2.5 5C2.5 6.381 3.619 7.5 5 7.5C6.381 7.5 7.5 6.381 7.5 5z";
+        strictEqual(runOutline(input, 1), normalizePath(expected));
+      });
+
+      test("Circle with distance = 3", () => {
+        const input =
+          "M18 5C18 6.656854249493 16.656854249493 8 15 8C13.343145750507 8 12 6.656854249493 12 5C12 3.343145750507 13.343145750507 2 15 2C16.656854249493 2 18 3.343145750507 18 5z";
+        const expected =
+          "M19.5 5C19.5 7.485 17.485 9.5 15 9.5C12.515 9.5 10.5 7.485 10.5 5C10.5 2.515 12.515 0.5 15 0.5C17.485 0.5 19.5 2.515 19.5 5M16.5 5C16.5 4.172 15.828 3.5 15 3.5C14.172 3.5 13.5 4.172 13.5 5C13.5 5.828 14.172 6.5 15 6.5C15.828 6.5 16.5 5.828 16.5 5z";
+        strictEqual(runOutline(input, 3), normalizePath(expected));
+      });
+
+      test("Circle with distance = 5", () => {
+        const input =
+          "M28 5C28 6.656854249493 26.656854249493 8 25 8C23.343145750507 8 22 6.656854249493 22 5C22 3.343145750507 23.343145750507 2 25 2C26.656854249493 2 28 3.343145750507 28 5z";
+        const expected =
+          "M30.5 5C30.5 8.038 28.038 10.5 25 10.5C21.962 10.5 19.5 8.038 19.5 5C19.5 1.962 21.962 -0.5 25 -0.5C28.038 -0.5 30.5 1.962 30.5 5M25.5 5C25.5 4.724 25.276 4.5 25 4.5C24.724 4.5 24.5 4.724 24.5 5C24.5 5.276 24.724 5.5 25 5.5C25.276 5.5 25.5 5.276 25.5 5z";
+        strictEqual(runOutline(input, 5), normalizePath(expected));
+      });
+    });
+
+    describe("Ellipses", () => {
+      test("Ellipse with distance = 1", () => {
+        const input =
+          "M7 5C7 6.6568542494927 6.1045694996616 8 5 8C3.8954305003384 8 3 6.6568542494927 3 5C3 3.3431457505073 3.8954305003384 2 5 2C6.1045694996616 2 7 3.3431457505073 7 5z";
+        const expected =
+          "M7.5 5C7.436 6.975 6.317 8.542 5 8.5C3.683 8.542 2.564 6.975 2.5 5C2.564 3.025 3.683 1.458 5 1.5C6.317 1.458 7.436 3.025 7.5 5M6.5 5C6.564 3.662 5.892 2.542 5 2.5C4.108 2.542 3.436 3.662 3.5 5C3.436 6.338 4.108 7.458 5 7.5C5.892 7.458 6.564 6.338 6.5 5z";
+        strictEqual(runOutline(input, 1), normalizePath(expected));
+      });
+
+      test("Ellipse with distance = 3", () => {
+        const input =
+          "M17 5C17 6.6568542494927 16.104569499662 8 15 8C13.895430500338 8 13 6.6568542494927 13 5C13 3.3431457505073 13.895430500338 2 15 2C16.104569499662 2 17 3.3431457505073 17 5z";
+        const expected =
+          "M18.5 5C18.309 7.613 16.742 9.627 15 9.5C13.258 9.627 11.691 7.613 11.5 5C11.691 2.387 13.258 0.373 15 0.5C16.742 0.373 18.309 2.387 18.5 5M15.5 5C15.691 4.299 15.467 3.627 15 3.5C14.533 3.627 14.309 4.299 14.5 5C14.309 5.701 14.533 6.373 15 6.5C15.467 6.373 15.691 5.701 15.5 5z";
+        strictEqual(runOutline(input, 3), normalizePath(expected));
+      });
+
+      test("Ellipse with distance = 5", () => {
+        const input =
+          "M27 5C27 6.6568542494927 26.104569499662 8 25 8C23.895430500338 8 23 6.6568542494927 23 5C23 3.3431457505073 23.895430500338 2 25 2C26.104569499662 2 27 3.3431457505073 27 5z";
+        const expected =
+          "M29.5 5C29.181 8.25 27.167 10.712 25 10.5C22.833 10.712 20.819 8.25 20.5 5C20.819 1.75 22.833 -0.712 25 -0.5C27.167 -0.712 29.181 1.75 29.5 5M24.5 5C24.819 4.936 25.042 4.712 25 4.5C24.958 4.712 25.181 4.936 25.5 5C25.181 5.064 24.958 5.288 25 5.5C25.042 5.288 24.819 5.064 24.5 5z";
+        strictEqual(runOutline(input, 5), normalizePath(expected));
+      });
+    });
+
+    describe("Curved paths", () => {
+      test("Bezier curve path with distance = 1", () => {
+        const input = "M10,10 C30,30 60,30 80,10 Z";
+        const expected =
+          "M11.207 10.5C30.517 29.81 59.483 29.81 78.793 10.5M81.207 9.5C60.517 30.19 29.483 30.19 8.793 9.5z";
+        strictEqual(runOutline(input, 1), normalizePath(expected));
+      });
+    });
+  });
+
+  describe("Open paths", () => {
+    describe("Simple lines", () => {
+      test("Diagonal line with distance = 1", () => {
+        const input = "M2 2L7 8";
+        const expected = "M2.384 1.68L7.384 7.68L6.616 8.32L1.616 2.32L2.384 1.68z";
+        strictEqual(runOutline(input, 1), normalizePath(expected));
+      });
+
+      test("Angled line with distance = 3", () => {
+        const input = "M15 2L13 8";
+        const expected = "M16.423 2.474L14.423 8.474L11.577 7.526L13.577 1.526L16.423 2.474z";
+        strictEqual(runOutline(input, 3), normalizePath(expected));
+      });
+
+      test("Diagonal line with distance = 2", () => {
+        const input = "M22 2L26 8";
+        const expected = "M22.832 1.445L26.832 7.445L25.168 8.555L21.168 2.555L22.832 1.445z";
+        strictEqual(runOutline(input, 2), normalizePath(expected));
+      });
+    });
+
+    describe("Multi-segment paths", () => {
+      test("Open polyline with distance = 1", () => {
+        const input = "M50,50 L100,50 L100,100";
+        const expected = "M50 49.5L100.5 49.5L100.5 100L99.5 100L99.5 50.5L50 50.5L50 49.5z";
+        strictEqual(runOutline(input, 1), expected);
+      });
+
+      test("Polyline with distance = 3", () => {
+        const input = "M10 30L10 90L140 90L140 30";
+        const expected = "M11.5 30L11.5 88.5L138.5 88.5L138.5 30L141.5 30L141.5 91.5L8.5 91.5L8.5 30L11.5 30z";
+        strictEqual(runOutline(input, 3), expected);
+      });
+    });
+
+    describe("Complex open paths", () => {
+      test("Zigzag polyline with distance = 7", () => {
+        const input = "M10 280L40 250L70 280L100 250L130 280";
+        const expected =
+          "M7.525 277.525L40 245.05L70 275.05L100 245.05L132.475 277.525L127.525 282.475L100 254.95L70 284.95L40 254.95L12.475 282.475L7.525 277.525z";
+        strictEqual(runOutline(input, 7), normalizePath(expected));
+      });
+
+      test("Zigzag polyline with distance = 3", () => {
+        const input = "M10 320L40 290L70 320L100 290L130 320";
+        const expected =
+          "M8.939 318.939L40 287.879L70 317.879L100 287.879L131.061 318.939L128.939 321.061L100 292.121L70 322.121L40 292.121L11.061 321.061L8.939 318.939z";
+        strictEqual(runOutline(input, 3), normalizePath(expected));
+      });
+    });
+  });
+
+  describe("Additional shapes", () => {
+    describe("Pentagon", () => {
+      test("Regular pentagon with distance = 2", () => {
+        const input = "M200 250L250 280L230 320L170 320L150 280z";
+        const expected =
+          "M200 248.834L251.309 279.619L230.618 321L169.382 321L148.691 279.619M151.309 280.381L170.618 319L229.382 319L248.691 280.381L200 251.166z";
+        strictEqual(runOutline(input, 2), normalizePath(expected));
+      });
+    });
+
+    describe("Mixed circles and ellipses", () => {
+      test("Horizontal ellipse with distance = 3", () => {
+        const input =
+          "M80 360C80 371.04569499662 66.56854249493 380 50 380C33.43145750507 380 20 371.04569499662 20 360C20 348.95430500338 33.43145750507 340 50 340C66.56854249493 340 80 348.95430500338 80 360z";
+        const expected =
+          "M81.5 360C81.627 371.683 67.524 381.309 50 381.5C32.476 381.309 18.373 371.683 18.5 360C18.373 348.317 32.476 338.691 50 338.5C67.524 338.691 81.627 348.317 81.5 360M78.5 360C78.373 349.592 65.613 341.309 50 341.5C34.387 341.309 21.627 349.592 21.5 360C21.627 370.408 34.387 378.691 50 378.5C65.613 378.691 78.373 370.408 78.5 360z";
+        strictEqual(runOutline(input, 3), normalizePath(expected));
+      });
+
+      test("Perfect circle with stroke = 1", () => {
+        const input =
+          "M240 360C240 371.04569499662 226.56854249493 380 210 380C193.43145750507 380 180 371.04569499662 180 360C180 348.95430500338 193.43145750507 340 210 340C226.56854249493 340 240 348.95430500338 240 360z";
+        const expected =
+          "M240.5 360C240.542 371.258 226.887 380.436 210 380.5C193.113 380.436 179.458 371.258 179.5 360C179.458 348.742 193.113 339.564 210 339.5C226.887 339.564 240.542 348.742 240.5 360M239.5 360C239.458 349.167 226.25 340.436 210 340.5C193.75 340.436 180.542 349.167 180.5 360C180.542 370.833 193.75 379.564 210 379.5C226.25 379.564 239.458 370.833 239.5 360z";
+        strictEqual(runOutline(input, 1), normalizePath(expected));
+      });
+    });
+
+    describe("Special cases", () => {
+      test("Reversed stroke scaled triangular path", () => {
+        const input = "M200 80H240L220 120z";
+        const expected = "M198.382 79H241.618L220 122.236M220 117.764L238.382 80H201.618z";
+        strictEqual(runOutline(input, 2), normalizePath(expected));
+      });
+
+      test("Straight line with stroke = 2", () => {
+        const input = "M200 100L280 140";
+        const expected = "M200.447 99.106L280.447 139.106L279.553 140.894L199.553 100.894L200.447 99.106z";
+        strictEqual(runOutline(input, 2), normalizePath(expected));
+      });
+    });
+  });
+
+  describe("Complex curve patterns", () => {
+    test("Simple curved outline", () => {
+      const input = "M10 10C20 20 40 20 50 10";
+      const expected =
+        "M10.354 9.646C20.177 19.47 39.823 19.47 49.646 9.646L50.354 10.354C40.177 20.53 19.823 20.53 9.646 10.354L10.354 9.646z";
+      strictEqual(runOutline(input, 1), normalizePath(expected));
+    });
+
+    test("Straight line with curved ends", () => {
+      const input = "M70 10C70 20 110 20 110 10";
+      const expected = "M70.5 10C70.5 19.75 109.5 19.75 109.5 10L110.5 10C110.5 20.25 69.5 20.25 69.5 10L70.5 10z";
+      strictEqual(runOutline(input, 1), normalizePath(expected));
+    });
+
+    test("Irregular curve with varying control points", () => {
+      const input = "M130 10C120 20 180 20 170 10";
+      const expected =
+        "M130.354 10.354C120.53 20.177 179.47 20.177 169.646 10.354L170.354 9.646C180.53 19.823 119.47 19.823 129.646 9.646L130.354 10.354z";
+      strictEqual(runOutline(input, 1), normalizePath(expected));
+    });
+
+    test("Deep curve with larger distance", () => {
+      const input = "M130 110C120 140 180 140 170 110";
+      const expected =
+        "M132.372 110.791C123.558 137.233 176.442 137.233 167.628 110.791L172.372 109.209C183.558 142.767 116.442 142.767 127.628 109.209L132.372 110.791z";
+      strictEqual(runOutline(input, 5), normalizePath(expected));
+    });
+  });
+
+  describe("Special path cases", () => {
+    test.skip("Partial circular arc (needs investigation)", () => {
+      // This test currently doesn't work correctly and needs further investigation
+      const input = "M80 80C80 104.853 100.147 125 125 125L125 80z";
+      const expected = "M85 85C85 104.33 100.67 120 120 120L120 85M130 75L130 130C99.624 130 75 105.376 75 75z";
+
+      // TODO: Fix issue with partial arc outlines
+      strictEqual(runOutline(input, 10), expected);
+    });
+
+    test("Triangle path outline with explicit horizontal command", () => {
+      const input = "M200 80H240L220 120z";
+      const expected = "M195.955 77.5H244.045L220 125.59M220 114.41L235.955 80H204.045z";
+      strictEqual(runOutline(input, 5), expected);
+    });
+  });
+});

--- a/src/transformers/outline/outline.ts
+++ b/src/transformers/outline/outline.ts
@@ -1,0 +1,245 @@
+import type { CommandM, SVGCommand } from "svg-pathdata";
+import { SVGPathData, SVGPathDataTransformer } from "svg-pathdata";
+import { calculateStandardCornerOffset, calculateCurveEndpointOffset, transformControlPoints } from "./math.ts";
+import type { Point, CommandWithPoint } from "../utils/geometry.ts";
+import { arePointsSame } from "../utils/geometry.ts";
+import { REVERSE_PATH } from "../reverse/reverse.ts";
+
+/**
+ * Creates a complete outline for any path (closed or open)
+ * @param distance Offset distance (thickness) of the outline
+ * @param commands SVG path commands to outline
+ * @returns New SVG commands forming the outline
+ */
+export function OUTLINE(distance: number, commands: SVGCommand[]): SVGCommand[] {
+  if (commands.length < 2) {
+    throw new Error("Paths must have at least 2 commands");
+  }
+
+  const toABS = SVGPathDataTransformer.TO_ABS();
+
+  const pathCommands: CommandWithPoint[] = commands.map(toABS).map(
+    // Extract points to check if the path is implicitly closed
+    SVGPathDataTransformer.INFO((command, px, py) => ({
+      ...command,
+      x: command.x ?? px,
+      y: command.y ?? py,
+    })),
+  );
+
+  // Check if path is explicitly closed with a CLOSE_PATH command or implicitly closed
+  // (first and last points are the same)
+  const isExplicitlyClosed = pathCommands.at(-1)?.type === SVGPathData.CLOSE_PATH;
+
+  // Handle closed paths (explicit or implicit)
+  if (isExplicitlyClosed || arePointsSame(pathCommands[0], pathCommands[pathCommands.length - 1])) {
+    // Prepare path commands - only remove CLOSE_PATH if explicitly closed
+    if (isExplicitlyClosed) {
+      pathCommands.pop(); // Remove the last CLOSE_PATH
+    }
+
+    // Create inner offset path
+    const innerPath = processPathWithOffset(pathCommands, -distance / 2);
+
+    // Create outer offset path
+    const outerPath = processPathWithOffset(pathCommands, distance / 2);
+
+    // Reverse the inner path to create a counterclockwise path
+    // This ensures proper path joining
+    const reversedInnerPath = REVERSE_PATH(innerPath);
+
+    // Combine outer path + reversed inner path to form complete outline
+    return [
+      // Add the outer path
+      ...outerPath,
+      // Add the reversed inner path
+      ...reversedInnerPath,
+      // Close the path
+      { type: SVGPathData.CLOSE_PATH },
+    ];
+  }
+
+  // For open paths, continue with the existing approach
+  // Handle all non-closed paths by converting them to closed paths
+  const reversedCommands = REVERSE_PATH(pathCommands);
+
+  // Connect the original path with the reversed path
+  const combinedPath = connectPaths(pathCommands, reversedCommands);
+
+  // Process as a closed path with half the distance
+  const transformedResult = processPathWithOffset(combinedPath, distance / 2);
+  transformedResult.push({ type: SVGPathData.CLOSE_PATH });
+  return transformedResult;
+}
+
+/**
+ * Connects two paths together, ensuring proper command types and smooth transitions
+ * @param pathA First path (original path)
+ * @param pathB Second path (reversed pathA)
+ * @returns A combined path with appropriate connections
+ */
+function connectPaths(pathA: SVGCommand[], pathB: SVGCommand[]): SVGCommand[] {
+  if (pathA.length < 2 || pathB.length < 2) {
+    throw new Error("Paths must have at least 2 commands");
+  }
+
+  // Create a copy of the first path
+  const result = [...pathA];
+
+  // Always add a LINE_TO connecting pathA to pathB
+  // Convert the first MOVE_TO of pathB to a LINE_TO
+  result.push({ ...(pathB[0] as CommandM), type: SVGPathData.LINE_TO });
+
+  // Add all remaining commands from pathB (skip the first MOVE_TO)
+  result.push(...pathB.slice(1));
+
+  // Always add a LINE_TO back to the start point to ensure proper closure
+  // This is critical for the offset calculation
+  result.push({ ...(pathA[0] as CommandM), type: SVGPathData.LINE_TO });
+  return result;
+}
+
+/**
+ * Processes a path with the given offset for closed paths only
+ * @param commands Path commands to offset
+ * @param distance Offset distance from the original path
+ * @returns New SVG commands forming the offset path
+ */
+function processPathWithOffset(commands: SVGCommand[], distance: number): SVGCommand[] {
+  if (commands.length < 2) return commands;
+
+  // Final result array
+  const transformedResult: SVGCommand[] = [];
+
+  // Extract commands with point coordinates in a single array using the transformer
+  const commandsWithPoints: CommandWithPoint[] = commands.map(
+    SVGPathDataTransformer.INFO((command, px, py) => ({
+      ...command,
+      x: command.x ?? px,
+      y: command.y ?? py,
+    })),
+  );
+
+  // Check if first and last points are the same (implicitly closed path)
+  const isImplicitlyClosed = arePointsSame(commandsWithPoints[0], commandsWithPoints[commandsWithPoints.length - 1]);
+
+  // If path is implicitly closed, prepare to handle the first MOVE_TO specially
+  if (isImplicitlyClosed) {
+    commandsWithPoints.shift(); // Remove the first command
+  }
+
+  const lastIndex = commandsWithPoints.length - 1;
+  const firstIndex = 0;
+
+  // Calculate new points with offset - directly calculating the offset and applying it
+  const offsetPoints: Point[] = commandsWithPoints.map((currentCmd, i) => {
+    // Get previous point, wrap around for first point
+    const prevCmd = commandsWithPoints[i > 0 ? i - 1 : lastIndex];
+    // Get next point, wrap around for last point
+    const nextCmd = commandsWithPoints[i < lastIndex ? i + 1 : firstIndex];
+
+    let offsetVector: Point;
+
+    // Check for curve endpoints
+    if (currentCmd.type === SVGPathData.CURVE_TO || nextCmd.type === SVGPathData.CURVE_TO) {
+      // Get incoming control point (from current command if it's a curve)
+      let cp2: Point | null = null;
+      if (currentCmd.type === SVGPathData.CURVE_TO) {
+        cp2 = { x: currentCmd.x2, y: currentCmd.y2 };
+      } else if (prevCmd && !arePointsSame(prevCmd, currentCmd)) {
+        // If no control point, use the previous point as direction
+        cp2 = prevCmd;
+      }
+
+      // Get outgoing control point (from next command if it's a curve)
+      let cp1: Point | null = null;
+      if (nextCmd.type === SVGPathData.CURVE_TO) {
+        cp1 = { x: nextCmd.x1, y: nextCmd.y1 };
+      } else if (nextCmd && !arePointsSame(nextCmd, currentCmd)) {
+        // If no control point, use the next point as direction
+        cp1 = nextCmd;
+      }
+
+      // Calculate offset using available control points
+      offsetVector = calculateCurveEndpointOffset(currentCmd, cp2, cp1, distance);
+    } else {
+      // Standard corner offset for non-curve points
+      offsetVector = calculateStandardCornerOffset(prevCmd, currentCmd, nextCmd, distance);
+    }
+
+    // Apply the offset vector
+    return {
+      x: currentCmd.x + offsetVector.x,
+      y: currentCmd.y + offsetVector.y,
+    };
+  });
+
+  // Process each command in a single pass - iterate directly over commandsWithPoints
+  for (let i = 0; i < commandsWithPoints.length; ++i) {
+    const cmd = commandsWithPoints[i]; // This already has x,y coordinates
+
+    // Get adjacent points for offset calculation
+    // Get previous point, wrap around for first point
+    const prevPoint = commandsWithPoints[i > 0 ? i - 1 : lastIndex];
+    // Calculate the new offset point
+    const offsetPoint = offsetPoints[i];
+    // Get the last new point
+    const prevOffsetPoint = offsetPoints[i > 0 ? i - 1 : lastIndex];
+
+    // Add the appropriate command to the result
+    switch (cmd.type) {
+      case SVGPathData.MOVE_TO:
+        transformedResult.push({ ...cmd, x: offsetPoint.x, y: offsetPoint.y });
+        break;
+
+      case SVGPathData.CURVE_TO: {
+        // Calculate new control points directly without intermediate variables
+        const { controlPoint1, controlPoint2 } = transformControlPoints(
+          prevPoint, // originalStartPoint
+          { x: cmd.x1, y: cmd.y1 }, // originalControlPoint1
+          { x: cmd.x2, y: cmd.y2 }, // originalControlPoint2
+          cmd, // originalEndPoint
+          prevOffsetPoint, // newStartPoint
+          offsetPoint, // newEndPoint
+        );
+
+        // Create new curve command
+        transformedResult.push({
+          ...cmd,
+          x: offsetPoint.x,
+          y: offsetPoint.y,
+          x1: controlPoint1.x,
+          y1: controlPoint1.y,
+          x2: controlPoint2.x,
+          y2: controlPoint2.y,
+        });
+        break;
+      }
+
+      case SVGPathData.HORIZ_LINE_TO:
+        transformedResult.push({ ...cmd, x: offsetPoint.x });
+        break;
+
+      case SVGPathData.VERT_LINE_TO:
+        transformedResult.push({ ...cmd, y: offsetPoint.y });
+        break;
+
+      case SVGPathData.LINE_TO:
+        transformedResult.push({ ...cmd, x: offsetPoint.x, y: offsetPoint.y });
+        break;
+    }
+  }
+
+  // Add the MOVE_TO at the beginning if the path was implicitly closed
+  if (isImplicitlyClosed && offsetPoints.length > 0) {
+    // Use the offset point for the last point as the new MOVE_TO point
+    transformedResult.unshift({
+      type: SVGPathData.MOVE_TO,
+      relative: false,
+      x: offsetPoints[lastIndex].x,
+      y: offsetPoints[lastIndex].y,
+    });
+  }
+
+  return transformedResult;
+}

--- a/src/transformers/reverse/reverse.test.ts
+++ b/src/transformers/reverse/reverse.test.ts
@@ -1,0 +1,80 @@
+import { test, describe } from "node:test";
+import { strictEqual } from "node:assert";
+
+import { SVGPathData } from "svg-pathdata";
+
+import { REVERSE_PATH } from "./reverse.ts";
+
+function runReversal(path: string): string {
+  const pathData = new SVGPathData(path).toAbs();
+  pathData.commands = REVERSE_PATH(pathData.commands);
+  return pathData.encode();
+}
+
+describe("Reverse paths", () => {
+  test("simple line path", () => {
+    const input = "M10,10 L20,20 L30,10";
+    const expected = "M30 10L20 20L10 10";
+    strictEqual(runReversal(input), expected);
+  });
+
+  test("horizontal and vertical lines", () => {
+    const input = "M10,10 H30 V30 H10";
+    const expected = "M10 30H30V10H10";
+    strictEqual(runReversal(input), expected);
+  });
+
+  test("closed path (with Z command)", () => {
+    const input = "M10,10 L20,20 L30,10 Z";
+    // The Z command is preserved in the reversed path
+    const expected = "M30 10L20 20L10 10z";
+    strictEqual(runReversal(input), expected);
+  });
+
+  test("path with cubic bezier curves", () => {
+    const input = "M10,10 C20,20 40,20 50,10";
+    // Reversed path with flipped control points
+    const expected = "M50 10C40 20 20 20 10 10";
+    strictEqual(runReversal(input), expected);
+  });
+
+  test("path with quadratic bezier curve (converted to cubic)", () => {
+    const input = "M10,10 Q25,25 40,10";
+    // Quadratic curve is converted to cubic in the reverse process
+    const expected = "M40 10C25 25 25 25 10 10";
+    strictEqual(runReversal(input), expected);
+  });
+
+  test("relative commands should be converted to absolute", () => {
+    const input = "m10,10 l10,10 l10,-10";
+    const expected = "M30 10L20 20L10 10";
+    strictEqual(runReversal(input), expected);
+  });
+
+  test("single point path", () => {
+    const input = "M10,10";
+    // A single point path results in just a move command
+    const expected = "M10 10";
+    strictEqual(runReversal(input), expected);
+  });
+
+  test("empty path", () => {
+    const input = "";
+    const expected = "";
+    strictEqual(runReversal(input), expected);
+  });
+
+  test("path closed both explicitly and implicitly", () => {
+    const input = "M10,10 L20,20 L30,10 L10,10 Z"; // Note: Last point (10,10) matches first point + Z
+    // Should still reverse correctly and maintain Z
+    const expected = "M10 10L30 10L20 20L10 10z";
+    strictEqual(runReversal(input), expected);
+  });
+
+  test("path closed only implicitly (without Z command)", () => {
+    const input = "M10,10 L20,20 L30,10 L10,10"; // Note: Last point matches first point, but no Z
+    // Should still reverse correctly and maintain implicit closure
+    const expected = "M10 10L30 10L20 20L10 10";
+    strictEqual(runReversal(input), expected);
+  });
+});

--- a/src/transformers/reverse/reverse.ts
+++ b/src/transformers/reverse/reverse.ts
@@ -1,0 +1,104 @@
+import { SVGPathData, type SVGCommand, SVGPathDataTransformer } from "svg-pathdata";
+
+/**
+ * Reverses the order of path commands to go from end to start
+ * IMPORTANT: This function expects absolute commands as input.
+ * It doesn't convert relative to absolute - use SVGPathDataTransformer.TO_ABS() first if needed.
+ * @param commands SVG path commands in absolute form to reverse
+ * @returns New SVG commands in reverse order with absolute coordinates
+ */
+export function REVERSE_PATH(commands: SVGCommand[]): SVGCommand[] {
+  if (commands.length < 2) return commands;
+
+  // Extract absolute points using the transformer to track current position
+  const points = commands.map(
+    SVGPathDataTransformer.INFO((command, px, py) => ({
+      ...command,
+      x: command.x ?? px,
+      y: command.y ?? py,
+    })),
+  );
+
+  // Check if path is explicitly closed (ends with CLOSE_PATH)
+  const isExplicitlyClosed = commands.at(-1)?.type === SVGPathData.CLOSE_PATH;
+
+  // Start with a move to the last explicit point
+  // (if path ends with Z, use the point before Z)
+  const startPointIndex = isExplicitlyClosed ? points.length - 2 : points.length - 1;
+  const reversed: SVGCommand[] = [
+    {
+      type: SVGPathData.MOVE_TO,
+      relative: false,
+      x: points[startPointIndex].x,
+      y: points[startPointIndex].y,
+    },
+  ];
+
+  // Process each segment in reverse order
+  for (let i = startPointIndex; i > 0; i--) {
+    const curCmd = points[i];
+    const prevPoint = points[i - 1];
+
+    // Handle the current command type
+    switch (curCmd.type) {
+      case SVGPathData.HORIZ_LINE_TO:
+        // Add a line to the previous point
+        reversed.push({ type: SVGPathData.HORIZ_LINE_TO, relative: false, x: prevPoint.x });
+        break;
+      case SVGPathData.VERT_LINE_TO:
+        // Add a line to the previous point
+        reversed.push({ type: SVGPathData.VERT_LINE_TO, relative: false, y: prevPoint.y });
+        break;
+
+      case SVGPathData.LINE_TO:
+      case SVGPathData.MOVE_TO:
+        // Add a line to the previous point
+        reversed.push({ type: SVGPathData.LINE_TO, relative: false, x: prevPoint.x, y: prevPoint.y });
+        break;
+
+      case SVGPathData.CURVE_TO:
+        // Reverse curve control points
+        reversed.push({
+          type: SVGPathData.CURVE_TO,
+          relative: false,
+          x: prevPoint.x,
+          y: prevPoint.y,
+          x1: curCmd.x2,
+          y1: curCmd.y2,
+          x2: curCmd.x1,
+          y2: curCmd.y1,
+        });
+        break;
+
+      // For completeness, handle quadratic curves too
+      case SVGPathData.QUAD_TO:
+        // Convert to cubic with equivalent control points
+        reversed.push({
+          type: SVGPathData.CURVE_TO,
+          relative: false,
+          x: prevPoint.x,
+          y: prevPoint.y,
+          // For quadratic to cubic conversion:
+          x1: curCmd.x1,
+          y1: curCmd.y1,
+          x2: curCmd.x1,
+          y2: curCmd.y1,
+        });
+        break;
+
+      // Skip close path - we'll add it at the end if needed
+      case SVGPathData.CLOSE_PATH:
+        break;
+
+      default:
+        console.debug("Skipping unsupported command type:", curCmd.type);
+    }
+  }
+
+  // If the original path was explicitly closed, preserve the Z command
+  if (isExplicitlyClosed) {
+    reversed.push({ type: SVGPathData.CLOSE_PATH });
+  }
+
+  return reversed;
+}

--- a/src/transformers/simplify/simplify.md
+++ b/src/transformers/simplify/simplify.md
@@ -1,0 +1,31 @@
+# Path Simplification
+
+Algorithms for simplifying SVG paths by removing redundant points while preserving visual appearance.
+
+## Overview
+
+Our implementation provides two main transformers:
+
+### 1. REMOVE_DUPLICATES
+
+Removes consecutive points that are at the same location.
+
+- Uses `minLength` threshold to determine when points are considered identical
+- Preserves first MOVE_TO and all CLOSE_PATH commands
+- Only processes line commands (LINE_TO, HORIZ_LINE_TO, VERT_LINE_TO)
+
+### 2. REMOVE_COLLINEAR
+
+Removes points that lie on a straight line between their neighbors.
+
+- Uses cross product for precise collinearity detection
+- Uses dot product to ensure segments form a continuous line
+- Preserves corners, curves, and path structure
+- Works on horizontal, vertical, and diagonal lines
+
+## Special Handling
+
+- Curves: Preserved as-is
+- Corners: Maintained to preserve path shape
+- Subpaths: Processed independently
+- Closed paths: Structure preserved

--- a/src/transformers/simplify/simplify.test.ts
+++ b/src/transformers/simplify/simplify.test.ts
@@ -1,0 +1,175 @@
+import { test, describe } from "node:test";
+import { strictEqual } from "node:assert";
+
+import { SVGPathData } from "svg-pathdata";
+import { REMOVE_COLLINEAR, REMOVE_DUPLICATES } from "./simplify.ts";
+
+function runRemoveCollinear(path: string): string {
+  const pathData = new SVGPathData(path).toAbs();
+  pathData.commands = REMOVE_COLLINEAR(pathData.commands);
+  return pathData.encode();
+}
+
+function runRemoveDuplicates(path: string): string {
+  return new SVGPathData(path).toAbs().transform(REMOVE_DUPLICATES()).encode();
+}
+
+function runFullSimplification(path: string): string {
+  const pathData = new SVGPathData(path).toAbs().transform(REMOVE_DUPLICATES());
+  pathData.commands = REMOVE_COLLINEAR(pathData.commands);
+  return pathData.encode();
+}
+
+function normalizePath(path: string): string {
+  return new SVGPathData(path).toAbs().encode();
+}
+
+describe("Remove collinear points", () => {
+  test("Horizontal line with collinear point", () => {
+    const input = "M10,10 L20,10 L30,10";
+    const expected = "M10 10L30 10";
+    strictEqual(runRemoveCollinear(input), expected);
+  });
+
+  test("Diagonal line with collinear point", () => {
+    const input = "M10,10 L20,20 L30,30";
+    const expected = "M10 10L30 30";
+    strictEqual(runRemoveCollinear(input), expected);
+  });
+
+  test("Vertical line with collinear point", () => {
+    const input = "M10,10 L10,20 L10,30";
+    const expected = "M10 10L10 30";
+    strictEqual(runRemoveCollinear(input), expected);
+  });
+
+  test("Multiple collinear sections", () => {
+    const input = "M10,10 L20,10 L30,10 L40,20 L50,30 L60,40 L60,50 L60,60";
+    const expected = "M10 10L30 10L60 40L60 60";
+    strictEqual(runRemoveCollinear(input), expected);
+  });
+
+  test("Preserves curves", () => {
+    const input = "M10,10 C20,20 30,20 40,10 L50,10 L60,10";
+    const expected = "M10 10C20 20 30 20 40 10L60 10";
+    strictEqual(runRemoveCollinear(input), expected);
+  });
+
+  test("Preserves closed paths", () => {
+    const input = "M10,10 L20,10 L30,10 L30,20 L10,20 Z";
+    const expected = "M10 10L30 10L30 20L10 20z";
+    strictEqual(runRemoveCollinear(input), expected);
+  });
+
+  test("Handles multiple subpaths", () => {
+    const input = "M10,10 L20,10 L30,10 M40,40 L50,40 L60,40";
+    const expected = "M10 10L30 10M40 40L60 40";
+    strictEqual(runRemoveCollinear(input), expected);
+  });
+});
+
+describe("Remove duplicate points", () => {
+  test("Exact duplicate points", () => {
+    const input = "M10,10 L10,10 L20,20";
+    const expected = "M10 10L20 20";
+    strictEqual(runRemoveDuplicates(input), expected);
+  });
+
+  test("Very close points (below tolerance)", () => {
+    const input = "M10,10 L10.0000001,10.0000001 L20,20";
+    const expected = "M10 10L20 20";
+    strictEqual(runRemoveDuplicates(input), expected);
+  });
+
+  test("Points that should not be removed (above tolerance)", () => {
+    const input = "M10,10 L10.01,10 L20,20";
+    const expected = normalizePath(input);
+    strictEqual(runRemoveDuplicates(input), expected);
+  });
+
+  test("Preserves curves with same endpoints", () => {
+    const input = "M10,10 C20,0 30,0 10,10";
+    const expected = normalizePath(input);
+    strictEqual(runRemoveDuplicates(input), expected);
+  });
+
+  test("Preserves first MOVE_TO", () => {
+    const input = "M10,10 M10,10 L20,20";
+    const expected = "M10 10L20 20";
+    strictEqual(runRemoveDuplicates(input), expected);
+  });
+});
+
+describe("Combined simplification", () => {
+  test("Complex path with duplicates and collinear points", () => {
+    const input = `M 10,10 
+                  L 10,10 
+                  L 20,10 
+                  L 30,10 
+                  L 40,20 
+                  L 50,30 
+                  L 50,30.0000001 
+                  L 60,40`;
+    const expected = "M10 10L30 10L60 40";
+
+    strictEqual(runFullSimplification(input), expected);
+  });
+
+  test("Preserves curves properly", () => {
+    const input = `M 10,10 
+                  C 20,5 30,5 40,10 
+                  L 50,10 
+                  L 60,10 
+                  Q 70,10 70,20 
+                  L 70,30 
+                  L 70,40 
+                  Z`;
+    const expected = "M10 10C20 5 30 5 40 10L60 10Q70 10 70 20L70 40z";
+    strictEqual(runFullSimplification(input), expected);
+  });
+
+  test("Handles multiple subpaths with mixed elements", () => {
+    const input = `M 10,10 
+                  L 30,10 
+                  L 40,10 
+                  C 50,10 60,20 60,30 
+                  L 60,40 
+                  L 60,50 
+                  M 100,100 
+                  L 100,110 
+                  L 100,120 
+                  Q 100,130 110,130 
+                  L 120,130 
+                  L 120,130.0000001 
+                  Z`;
+    const expected = "M10 10L40 10C50 10 60 20 60 30L60 50M100 100L100 120Q100 130 110 130L120 130z";
+    strictEqual(runFullSimplification(input), expected);
+  });
+});
+
+// A more complex test to check for potential regression
+describe("Edge cases", () => {
+  test("U-turns and tight angles", () => {
+    const input = "M10,10 L20,20 L20,10 L10,10";
+    const expected = normalizePath(input);
+    strictEqual(runFullSimplification(input), expected);
+  });
+
+  test("Nearly collinear points (just outside tolerance)", () => {
+    const input = "M10,10 L20,10.011 L30,10";
+    const expected = normalizePath(input);
+    strictEqual(runRemoveCollinear(input), expected);
+  });
+
+  test("Empty path or single point", () => {
+    const input = "M10,10";
+    const expected = normalizePath(input);
+    strictEqual(runFullSimplification(input), expected);
+  });
+
+  test("Path with only curves", () => {
+    const input = "M10,10 C20,0 30,0 40,10 C50,20 60,20 70,10";
+    const expected = normalizePath(input);
+    strictEqual(runFullSimplification(input), expected);
+  });
+});

--- a/src/transformers/simplify/simplify.ts
+++ b/src/transformers/simplify/simplify.ts
@@ -1,0 +1,139 @@
+import { SVGPathData, SVGPathDataTransformer } from "svg-pathdata";
+import type { SVGCommand } from "svg-pathdata";
+import { arePointsSame, dotProduct, createVector, crossProduct } from "../utils/geometry.ts";
+import type { CommandWithPoint, Point } from "../utils/geometry.ts";
+
+/**
+ * Transformer that removes duplicate points
+ * @param minLength Distance threshold below which points are considered identical
+ * @returns A transformer function that removes duplicate points
+ */
+export function REMOVE_DUPLICATES(minLength = 1e-6) {
+  let isFirstMove = true;
+  let prevPoint: Point | null = null;
+
+  return SVGPathDataTransformer.INFO((cmd, px, py) => {
+    // Get the current command's absolute coordinates
+    const currentPoint = { x: cmd.x ?? px, y: cmd.y ?? py };
+
+    switch (cmd.type) {
+      // Always keep CLOSE_PATH
+      case SVGPathData.CLOSE_PATH:
+        prevPoint = null;
+        return cmd;
+
+      // Always keep first MOVE_TO
+      case SVGPathData.MOVE_TO: {
+        if (isFirstMove) {
+          isFirstMove = false;
+          break;
+        }
+        // Check for duplicate points
+        if (prevPoint && arePointsSame(currentPoint, prevPoint, minLength)) {
+          return [];
+        }
+        break;
+      }
+
+      // Only check these line commands for duplicates
+      case SVGPathData.LINE_TO:
+      case SVGPathData.HORIZ_LINE_TO:
+      case SVGPathData.VERT_LINE_TO:
+        // Check for duplicate points
+        if (prevPoint && arePointsSame(currentPoint, prevPoint, minLength)) {
+          return [];
+        }
+        break;
+    }
+
+    // Update previous point for next command
+    prevPoint = currentPoint;
+    return cmd;
+  });
+}
+
+/**
+ * Determines if three points are collinear and the middle point is removable
+ * Uses a mathematically precise cross product approach
+ *
+ * @param p1 First point
+ * @param p2 Middle point that might be removed
+ * @param p3 Last point
+ * @returns true if the points are collinear and p2 can be removed
+ */
+function arePointsCollinear(p1: Point, p2: Point, p3: Point): boolean {
+  // Create vectors using utility function
+  const v1 = createVector(p1, p2);
+  const v2 = createVector(p2, p3);
+
+  // Cross product: if it's zero (or very close), the points are collinear
+  // Using the imported crossProduct function from geometry.ts
+  const cross = crossProduct(v1, v2);
+  const isCollinear = Math.abs(cross) < 1e-10;
+
+  // Dot product using utility function
+  const dot = dotProduct(v1, v2);
+  const sameDirection = dot > 0;
+
+  // Points are collinear and middle point can be removed if:
+  // 1. They form a straight line (cross product ≈ 0)
+  // 2. The segments point in same direction (not a sharp corner)
+  return isCollinear && sameDirection;
+}
+
+/**
+ * Process a single subpath and remove collinear points
+ * This is a batch processor that takes an array of commands for a single subpath (no additional MOVE_TO commands)
+ * @param commands Array of SVG path commands to process (must be absolute)
+ * @returns New array with collinear points removed
+ */
+export function REMOVE_COLLINEAR(commands: SVGCommand[]) {
+  if (commands.length <= 2) return commands;
+
+  // Extract commands with point coordinates
+  const commandsWithPoints: CommandWithPoint[] = commands.map(
+    SVGPathDataTransformer.INFO((command, previousX, previousY) => ({
+      ...command,
+      x: command.x ?? previousX,
+      y: command.y ?? previousY,
+    })),
+  );
+
+  // Create result array and keep the first command
+  const result: CommandWithPoint[] = [commandsWithPoints[0]];
+  let close: CommandWithPoint | undefined = undefined;
+  if (commandsWithPoints[commandsWithPoints.length - 1].type === SVGPathData.CLOSE_PATH) {
+    close = commandsWithPoints.pop();
+  }
+
+  let prevCmd = result[0];
+
+  // Check triplets of points for collinearity
+  for (let i = 1; i < commandsWithPoints.length - 1; ++i) {
+    const cmd = commandsWithPoints[i];
+    const nextCmd = commandsWithPoints[i + 1];
+
+    if (
+      nextCmd &&
+      nextCmd.type !== SVGPathData.CLOSE_PATH &&
+      (cmd.type === SVGPathData.LINE_TO ||
+        cmd.type === SVGPathData.HORIZ_LINE_TO ||
+        cmd.type === SVGPathData.VERT_LINE_TO)
+    ) {
+      if (arePointsCollinear(prevCmd, cmd, nextCmd)) {
+        // Skip this command - don't add to result
+        continue;
+      }
+    }
+    // Add the current command to the result
+    result.push(cmd);
+    prevCmd = cmd;
+  }
+
+  result.push(commandsWithPoints[commandsWithPoints.length - 1]);
+  if (close) {
+    result.push(close);
+  }
+
+  return result;
+}

--- a/src/transformers/utils/debug.ts
+++ b/src/transformers/utils/debug.ts
@@ -1,0 +1,61 @@
+import type { SVGCommand } from "svg-pathdata";
+import { SVGPathData } from "svg-pathdata";
+import type { Point } from "./geometry.ts";
+
+/**
+ * Debug utility to convert command type to string
+ */
+function typeToString(cmd: SVGCommand): string {
+  switch (cmd.type) {
+    case SVGPathData.CLOSE_PATH:
+      return "CLOSE_PATH";
+    case SVGPathData.MOVE_TO:
+      return "MOVE_TO";
+    case SVGPathData.HORIZ_LINE_TO:
+      return "HORIZ_LINE_TO";
+    case SVGPathData.VERT_LINE_TO:
+      return "VERT_LINE_TO";
+    case SVGPathData.LINE_TO:
+      return "LINE_TO";
+    case SVGPathData.CURVE_TO:
+      return "CURVE_TO";
+    case SVGPathData.SMOOTH_CURVE_TO:
+      return "SMOOTH_CURVE_TO";
+    case SVGPathData.QUAD_TO:
+      return "QUAD_TO";
+    case SVGPathData.SMOOTH_QUAD_TO:
+      return "SMOOTH_QUAD_TO";
+    case SVGPathData.ARC:
+      return "ARC";
+  }
+}
+
+type DebugCommand = string | number | boolean | null | undefined | SVGCommand | Point;
+
+/**
+ * Debug utility to stringify a command
+ */
+function debugCommand(item: DebugCommand): unknown {
+  if (!item || typeof item !== "object") {
+    return item;
+  }
+  if ("type" in item) {
+    return item ? `${typeToString(item)}: ${JSON.stringify(item)}` : "null";
+  }
+  return JSON.stringify(item);
+}
+
+/**
+ * Debug utility to log information
+ * Can be conditionally disabled
+ */
+export function debugString(...args: (DebugCommand | DebugCommand[])[]): void {
+  const pArgs = args.map((a) => {
+    if (Array.isArray(a)) {
+      return a.map(debugCommand);
+    }
+    return debugCommand(a);
+  });
+  // TODO: disable this conditionally
+  console.debug(...pArgs);
+}

--- a/src/transformers/utils/geometry.ts
+++ b/src/transformers/utils/geometry.ts
@@ -1,0 +1,126 @@
+import type { SVGCommand } from "svg-pathdata";
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/**
+ * Type combining an SVG command with point coordinates
+ * This makes it easier to track both command data and point position together
+ */
+export type CommandWithPoint = SVGCommand & Point;
+
+export function isNumberValid(n: number): boolean {
+  return !Number.isNaN(n) && Number.isFinite(n);
+}
+
+/**
+ * Creates a vector from two points
+ * @param p1 Start point
+ * @param p2 End point
+ * @returns Vector from p1 to p2
+ */
+export function createVector(p1: Point, p2: Point): Point {
+  return { x: p2.x - p1.x, y: p2.y - p1.y };
+}
+
+/**
+ * Calculates the magnitude (length) of a vector
+ * @param v Vector as a Point object
+ * @returns The magnitude of the vector
+ */
+export function magnitude(v: Point): number {
+  return Math.sqrt(v.x * v.x + v.y * v.y);
+}
+
+/**
+ * Normalizes a vector to unit length
+ * @param v Vector as a Point object
+ * @returns A unit vector in the same direction
+ */
+export function normalizeVector(v: Point): Point {
+  const mag = magnitude(v);
+  if (mag < 0.000001) return { x: 0, y: 0 };
+  return { x: v.x / mag, y: v.y / mag };
+}
+
+/**
+ * Calculates the dot product of two vectors
+ * @param v1 First vector
+ * @param v2 Second vector
+ * @returns The dot product
+ */
+export function dotProduct(v1: Point, v2: Point): number {
+  return v1.x * v2.x + v1.y * v2.y;
+}
+
+/**
+ * Calculates the cross product of two vectors
+ * @param v1 First vector
+ * @param v2 Second vector
+ * @returns The cross product (z-component)
+ */
+export function crossProduct(v1: Point, v2: Point): number {
+  return v1.x * v2.y - v1.y * v2.x;
+}
+
+/**
+ * Scales a vector by a scalar value
+ * @param v Vector to scale
+ * @param scale Scaling factor
+ * @returns The scaled vector
+ */
+export function scaleVector(v: Point, scale: number): Point {
+  return { x: v.x * scale, y: v.y * scale };
+}
+
+/**
+ * Rotates a vector around the origin by the specified angle
+ * @param v Vector to rotate
+ * @param angleRadians Angle in radians
+ * @returns The rotated vector
+ */
+export function rotateVector(v: Point, angleRadians: number): Point {
+  const cos = Math.cos(angleRadians);
+  const sin = Math.sin(angleRadians);
+  return {
+    x: v.x * cos - v.y * sin,
+    y: v.x * sin + v.y * cos,
+  };
+}
+
+/**
+ * Creates a perpendicular vector by rotating 90 degrees around the origin
+ * @param v Vector to rotate
+ * @param clockwise Whether to rotate clockwise (true) or counterclockwise (false)
+ * @returns Perpendicular vector
+ */
+export function perpendicularVector(v: Point, clockwise = false): Point {
+  return clockwise ? { x: v.y, y: -v.x } : { x: -v.y, y: v.x };
+}
+
+/**
+ * Calculates the rotation angle between two vectors
+ * @param v1 First vector
+ * @param v2 Second vector
+ * @returns The angle difference in radians
+ */
+export function calculateRotation(v1: Point, v2: Point): number {
+  const angle1 = Math.atan2(v1.y, v1.x);
+  const angle2 = Math.atan2(v2.y, v2.x);
+  return angle2 - angle1;
+}
+
+/**
+ * Checks if two points are the same within a tolerance
+ * @param p1 First point
+ * @param p2 Second point
+ * @param tolerance Distance tolerance (default: 0.0001)
+ * @returns Whether points are considered the same
+ */
+export function arePointsSame(p1?: Point | null, p2?: Point | null, tolerance = 0.0001): boolean {
+  if (!p1 || !p2) return false;
+  if (!tolerance) return p1.x === p2.x && p1.y === p2.y;
+  return Math.abs(p1.x - p2.x) < tolerance && Math.abs(p1.y - p2.y) < tolerance;
+}


### PR DESCRIPTION
for now this is just rough implementation and needs some polishing,

TODO: splitting and processing multi-paths

basic usage:
```ts
function createOutline(commands: SVGCommand[]) {
  const pathData: new SVGPathData2(commands.map((c) => ({ ...c }))); // make clone
  pathData.annotateArcs().aToC().normalizeST().qtToC().toAbs() // convert to absolutes and brazier
  pathData.transform(REMOVE_DUPLICATES()); // remove duplicates
  pathData.commands = REMOVE_COLLINEAR(pathData.commands); // remove collinear's
  pathData.commands = OUTLINE(size, pathData.commands) // generate outline
  return pathData.encode()
}
```

@nfroidure do you think this is a good place to add my little script to convert outlines to path and all other utility functions?

i was investigating bunch-of issues over couple of weeks in `svg-pathdata`,
- some curves are not properly converted to brazier
- skew is not working properly
  - looks like we are applying `atan` instead of `tan`
- there are issues with bound calculations
